### PR TITLE
OAG database demo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -182,3 +182,7 @@ cython_debug/
 
 # Jupyter Notebooks
 *.ipynb
+
+# SQLite databases (ignore for now).
+*.sqlite
+*.sqlite-journal

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ build-backend = "hatchling.build"
 
 [project.scripts]
 convert-oag-data = "commands.convert_oag_data:run"
+oag-query = "commands.oag_query:run"
 
 [tool.ruff]
 # Use Black-compatible defaults

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,10 +16,12 @@ readme = "README.md"
 license = "MIT"
 
 dependencies = [
+    "click",
     "numpy",
     "scipy",
     "pandas",
     "pyproj",
+    "tqdm",
     "xarray"
 ]
 
@@ -34,6 +36,9 @@ dev = [
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
+
+[project.scripts]
+convert-oag-data = "commands.convert_oag_data:run"
 
 [tool.ruff]
 # Use Black-compatible defaults

--- a/src/commands/convert_oag_data.py
+++ b/src/commands/convert_oag_data.py
@@ -8,8 +8,8 @@ from parsers.OAG_reader import read_oag_file
 
 
 @click.command()
-@click.argument('in-file', help='OAG data CSV file')
-@click.argument('db-file', help='Output database file')
+@click.argument('in-file')
+@click.argument('db-file')
 def run(in_file, db_file):
     if os.path.exists(db_file):
         raise RuntimeError(f'Database file {db_file} already exists.')

--- a/src/commands/convert_oag_data.py
+++ b/src/commands/convert_oag_data.py
@@ -1,21 +1,27 @@
+import os
+
 import click
 from tqdm import tqdm
 
-from parsers.OAG_reader import read_oag_file
 from missions.OAG_db import OAGDatabase
+from parsers.OAG_reader import read_oag_file
 
 
 @click.command()
-@click.option('--in-file', '-i', help='OAG data CSV file')
-@click.option('--db-file', '-d', help='Output database file')
+@click.argument('in-file', help='OAG data CSV file')
+@click.argument('db-file', help='Output database file')
 def run(in_file, db_file):
+    if os.path.exists(db_file):
+        raise RuntimeError(f'Database file {db_file} already exists.')
     db = OAGDatabase(db_file, write_mode=True)
 
+    nlines = -1  # (Skip header line.)
     with open(in_file) as fp:
-        nlines = len(fp.readlines())
+        for _ in fp:
+            nlines += 1
 
     n = 0
-    for entry in tqdm(read_oag_file(in_file), total=nlines-1):
+    for entry in tqdm(read_oag_file(in_file), total=nlines):
         db.add(entry, commit=False)
         n += 1
         if n % 10000 == 0:

--- a/src/commands/convert_oag_data.py
+++ b/src/commands/convert_oag_data.py
@@ -1,0 +1,26 @@
+import click
+from tqdm import tqdm
+
+from parsers.OAG_reader import read_oag_file
+from missions.OAG_db import OAGDatabase
+
+
+@click.command()
+@click.option('--in-file', '-i', help='OAG data CSV file')
+@click.option('--db-file', '-d', help='Output database file')
+def run(in_file, db_file):
+    db = OAGDatabase(db_file, write_mode=True)
+
+    with open(in_file) as fp:
+        nlines = len(fp.readlines())
+
+    n = 0
+    for entry in tqdm(read_oag_file(in_file), total=nlines-1):
+        db.add(entry, commit=False)
+        n += 1
+        if n % 10000 == 0:
+            db.conn.commit()
+
+
+if __name__ == '__main__':
+    run()

--- a/src/commands/oag_query.py
+++ b/src/commands/oag_query.py
@@ -1,0 +1,50 @@
+import os
+import re
+
+import click
+
+from missions.OAG_db import Comparison, Condition, OAGDatabase
+
+CONDITION_RE = re.compile(r'^([a-zA-Z0-9_]+)([=<>!]+)(.*)$')
+
+
+@click.command()
+@click.argument('db-file')
+@click.option('--limit', '-l', default=10, type=int,
+              help='Limit the number of results to display')
+@click.argument('conditions', nargs=-1)
+def run(db_file, limit, conditions: tuple[str, ...]):
+    if not os.path.exists(db_file):
+        raise RuntimeError(f'Database file {db_file} does not exist.')
+
+    db = OAGDatabase(db_file, write_mode=False)
+    if not conditions:
+        for index, entry in enumerate(db()):
+            if index >= limit:
+                break
+            print(entry)
+            print('')
+    else:
+        query_conditions = []
+        for condition in conditions:
+            result = CONDITION_RE.match(condition)
+            if not result:
+                raise ValueError(f'Invalid condition: {condition}')
+            field, cond, value = result.groups()
+            query_conditions.append(
+                Condition(
+                    field=field,
+                    value=value.strip(),
+                    comp=Comparison(cond)
+                )
+            )
+
+        for index, entry in enumerate(db(*query_conditions)):
+            if index >= limit:
+                break
+            print(entry)
+            print('')
+
+
+if __name__ == '__main__':
+    run()

--- a/src/commands/oag_query.py
+++ b/src/commands/oag_query.py
@@ -10,8 +10,9 @@ CONDITION_RE = re.compile(r'^([a-zA-Z0-9_]+)([=<>!]+)(.*)$')
 
 @click.command()
 @click.argument('db-file')
-@click.option('--limit', '-l', default=10, type=int,
-              help='Limit the number of results to display')
+@click.option(
+    '--limit', '-l', default=10, type=int, help='Limit the number of results to display'
+)
 @click.argument('conditions', nargs=-1)
 def run(db_file, limit, conditions: tuple[str, ...]):
     if not os.path.exists(db_file):
@@ -32,11 +33,7 @@ def run(db_file, limit, conditions: tuple[str, ...]):
                 raise ValueError(f'Invalid condition: {condition}')
             field, cond, value = result.groups()
             query_conditions.append(
-                Condition(
-                    field=field,
-                    value=value.strip(),
-                    comp=Comparison(cond)
-                )
+                Condition(field=field, value=value.strip(), comp=Comparison(cond))
             )
 
         for index, entry in enumerate(db(*query_conditions)):

--- a/src/missions/OAG_db.py
+++ b/src/missions/OAG_db.py
@@ -47,7 +47,8 @@ class OAGDatabase:
             raise RuntimeError("Database is not in write mode")
         cur = self.conn.cursor()
         placeholders = '?, ' * 31 + '?'
-        cur.execute(f"""
+        cur.execute(
+            f"""
             INSERT INTO entries (
                 carrier, fltno, depapt, depcity, depctry, arrapt, arrcity,
                 arrctry, deptim, arrtim, arrday, elptim, days, govt_app,
@@ -55,20 +56,42 @@ class OAGDatabase:
                 restrict, domint, efffrom, effto, routing,
                 longest, distance, sad, acft_owner,
                 operating, duplicate, NFlts
-            ) VALUES ({placeholders})""", (
-            e.carrier, e.fltno,
-            e.depapt, e.depcity, e.depctry,
-            e.arrapt, e.arrcity, e.arrctry,
-            e.deptim.isoformat()[:5], e.arrtim.isoformat()[:5], e.arrday,
-            e.elptim.total_seconds() // 60,
-            ''.join(sorted([str(day.value) for day in e.days])),
-            e.govt_app, e.comm10_50, e.genacft, e.inpacft,
-            e.service.value, e.seats, e.tons,
-            e.restrict, e.domint[0].value + e.domint[1].value,
-            e.efffrom, e.effto, e.routing,
-            e.longest, e.distance, e.sad, e.acft_owner,
-            e.operating, e.duplicate, e.NFlts
-        ))
+            ) VALUES ({placeholders})""",
+            (
+                e.carrier,
+                e.fltno,
+                e.depapt,
+                e.depcity,
+                e.depctry,
+                e.arrapt,
+                e.arrcity,
+                e.arrctry,
+                e.deptim.isoformat()[:5],
+                e.arrtim.isoformat()[:5],
+                e.arrday,
+                e.elptim.total_seconds() // 60,
+                ''.join(sorted([str(day.value) for day in e.days])),
+                e.govt_app,
+                e.comm10_50,
+                e.genacft,
+                e.inpacft,
+                e.service.value,
+                e.seats,
+                e.tons,
+                e.restrict,
+                e.domint[0].value + e.domint[1].value,
+                e.efffrom,
+                e.effto,
+                e.routing,
+                e.longest,
+                e.distance,
+                e.sad,
+                e.acft_owner,
+                e.operating,
+                e.duplicate,
+                e.NFlts,
+            ),
+        )
         if commit:
             self.conn.commit()
 

--- a/src/missions/OAG_db.py
+++ b/src/missions/OAG_db.py
@@ -1,0 +1,83 @@
+import sqlite3
+
+from parsers.OAG_reader import OAGEntry
+
+
+
+class OAGDatabase:
+    def __init__(self, db_path: str, write_mode: bool = False):
+        self.db_path = db_path
+        self.write_mode = write_mode
+        self.conn = sqlite3.connect(self.db_path)
+        if self.write_mode:
+            self._ensure_schema()
+
+    def add(self, e: OAGEntry, commit: bool = True):
+        if not self.write_mode:
+            raise RuntimeError("Database is not in write mode")
+        cur = self.conn.cursor()
+        placeholders = '?, ' * 31 + '?'
+        cur.execute(f"""
+            INSERT INTO entries (
+                carrier, fltno, depapt, depcity, depctry, arrapt, arrcity,
+                arrctry, deptim, arrtim, arrday, elptim, days, govt_app,
+                comm10_50, genacft, inpacft, service, seats, tons,
+                restrict, domint, efffrom, effto, routing,
+                longest, distance, sad, acft_owner,
+                operating, duplicate, NFlts
+            ) VALUES ({placeholders})""", (
+            e.carrier, e.fltno,
+            e.depapt, e.depcity, e.depctry,
+            e.arrapt, e.arrcity, e.arrctry,
+            e.deptim.isoformat()[:5], e.arrtim.isoformat()[:5], e.arrday,
+            e.elptim.total_seconds() // 60,
+            ''.join(sorted([str(day.value) for day in e.days])),
+            e.govt_app, e.comm10_50, e.genacft, e.inpacft,
+            e.service.value, e.seats, e.tons,
+            e.restrict, e.domint[0].value + e.domint[1].value,
+            e.efffrom, e.effto, e.routing,
+            e.longest, e.distance, e.sad, e.acft_owner,
+            e.operating, e.duplicate, e.NFlts
+        ))
+        if commit:
+            self.conn.commit()
+
+    def _ensure_schema(self):
+        cur = self.conn.cursor()
+        cur.execute("""
+            CREATE TABLE IF NOT EXISTS entries (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                carrier TEXT NOT NULL,
+                fltno INTEGER NOT NULL,
+                depapt TEXT NOT NULL,
+                depcity TEXT NOT NULL,
+                depctry TEXT,
+                arrapt TEXT NOT NULL,
+                arrcity TEXT NOT NULL,
+                arrctry TEXT,
+                deptim TEXT NOT NULL,
+                arrtim TEXT NOT NULL,
+                arrday INTEGER NOT NULL,
+                elptim INTEGER NOT NULL,
+                days TEXT NOT NULL,
+                govt_app BOOLEAN NOT NULL,
+                comm10_50 INTEGER,
+                genacft TEXT NOT NULL,
+                inpacft TEXT NOT NULL,
+                service TEXT NOT NULL,
+                seats INTEGER NOT NULL,
+                tons REAL NOT NULL,
+                restrict TEXT,
+                domint TEXT NOT NULL,
+                efffrom TEXT NOT NULL,
+                effto TEXT NOT NULL,
+                routing TEXT NOT NULL,
+                longest BOOLEAN NOT NULL,
+                distance INTEGER NOT NULL,
+                sad TEXT,
+                acft_owner TEXT,
+                operating BOOLEAN NOT NULL,
+                duplicate TEXT,
+                NFlts INTEGER NOT NULL
+            )
+        """)

--- a/src/parsers/OAG_reader.py
+++ b/src/parsers/OAG_reader.py
@@ -22,6 +22,7 @@ class DomesticInternational(str, Enum):
     DOMESTIC = 'D'
     INTERNATIONAL = 'I'
 
+
 DomInt = tuple[DomesticInternational, DomesticInternational]
 
 
@@ -35,6 +36,7 @@ class ServiceType(str, Enum):
 # Some information here:
 #  https://knowledge.oag.com/docs/schedules-direct-data-fields-explained
 
+
 @dataclass
 class OAGEntry:
     """A single entry in the OAG flight schedule data.
@@ -43,44 +45,44 @@ class OAGEntry:
     Prateek.
     """
 
-    carrier: str            # [ 1] = COLUMN NUMBER IN INPUT CSV FILE
-    fltno: int              # [ 2]
-    depapt: str             # [ 3]
-    depcity: str            # [ 4]
-    depctry: str | None     # [ 5]
-    arrapt: str             # [ 6]
-    arrcity: str            # [ 7]
-    arrctry: str | None     # [ 8]
-    deptim: time            # [ 9]
-    arrtim: time            # [10]
-    arrday: int             # [11] -1, 0, +1, +2  TODO: CHECK MEANING
-    elptim: timedelta       # [12]
-    days: set[DayOfWeek]    # [13] Set of days of week (M=1, S=7)
+    carrier: str  # [ 1] = COLUMN NUMBER IN INPUT CSV FILE
+    fltno: int  # [ 2]
+    depapt: str  # [ 3]
+    depcity: str  # [ 4]
+    depctry: str | None  # [ 5]
+    arrapt: str  # [ 6]
+    arrcity: str  # [ 7]
+    arrctry: str | None  # [ 8]
+    deptim: time  # [ 9]
+    arrtim: time  # [10]
+    arrday: int  # [11] -1, 0, +1, +2  TODO: CHECK MEANING
+    elptim: timedelta  # [12]
+    days: set[DayOfWeek]  # [13] Set of days of week (M=1, S=7)
     # stops                 # [14] ALL ZERO
     # intapt                # [15] ALL EMPTY
     # acftchange            # [16] ALL EMPTY
-    govt_app: bool          # [17] Government approval required (X OR EMPTY)
-    comm10_50: int | None   # [18] TODO: WHAT'S THIS? EITHER 10 OR EMPTY
-    genacft: str            # [19] TODO: 81 VALUES ⇒ SEPARATE TABLE?
-    inpacft: str            # [20] TODO: 181 VALUES ⇒ SEPARATE TABLE?
-    service: ServiceType    # [21]
-    seats: int              # [22]
-    tons: float             # [23]
-    restrict: str | None    # [24] TODO: WHAT IS THIS?
-    domint: DomInt          # [25]
-    efffrom: date           # [26]
-    effto: date             # [27]
-    routing: str            # [28]
-    longest: bool           # [29] "L" or EMPTY
-    distance: int           # [30]
-    sad: str | None         # [31] TODO: WHAT IS THIS?
+    govt_app: bool  # [17] Government approval required (X OR EMPTY)
+    comm10_50: int | None  # [18] TODO: WHAT'S THIS? EITHER 10 OR EMPTY
+    genacft: str  # [19] TODO: 81 VALUES ⇒ SEPARATE TABLE?
+    inpacft: str  # [20] TODO: 181 VALUES ⇒ SEPARATE TABLE?
+    service: ServiceType  # [21]
+    seats: int  # [22]
+    tons: float  # [23]
+    restrict: str | None  # [24] TODO: WHAT IS THIS?
+    domint: DomInt  # [25]
+    efffrom: date  # [26]
+    effto: date  # [27]
+    routing: str  # [28]
+    longest: bool  # [29] "L" or EMPTY
+    distance: int  # [30]
+    sad: str | None  # [31] TODO: WHAT IS THIS?
     # mcd                   # [32] ALL EMPTY
     # flt_dupe              # [33] ALL EMPTY
     acft_owner: str | None  # [34]
-    operating: bool         # [35] "O" OR EMPTY
+    operating: bool  # [35] "O" OR EMPTY
     # ghost                 # [36] ALL EMPTY
-    duplicate: str | None   # [37] TODO: WHAT IS THIS?  "D", "P" OR EMPTY
-    NFlts: int              # [38]
+    duplicate: str | None  # [37] TODO: WHAT IS THIS?  "D", "P" OR EMPTY
+    NFlts: int  # [38]
 
     @classmethod
     def from_csv_row(cls, row: list[str]) -> 'OAGEntry':
@@ -143,8 +145,10 @@ class OAGEntry:
             tons=float(row[22]),
             # TODO: USE ENUMERATION HERE?
             restrict=row[23] if row[23] else None,
-            domint=(DomesticInternational(row[24][0]),
-                    DomesticInternational(row[24][1])),
+            domint=(
+                DomesticInternational(row[24][0]),
+                DomesticInternational(row[24][1]),
+            ),
             efffrom=make_date(row[25]),
             effto=make_date(row[26]),
             routing=row[27],
@@ -154,7 +158,7 @@ class OAGEntry:
             acft_owner=row[33] if row[33] else None,
             operating=(row[34].strip().upper() == 'O'),
             duplicate=row[36] if row[36] else None,
-            NFlts=make_int(row[37])
+            NFlts=make_int(row[37]),
         )
 
     @classmethod
@@ -169,23 +173,41 @@ class OAGEntry:
         row = row[1:]  # Skip the ID column
 
         return cls(
-            carrier=row[0], fltno=row[1],
-            depapt=row[2], depcity=row[3], depctry=row[4],
-            arrapt=row[5], arrcity=row[6], arrctry=row[7],
-            deptim=time.fromisoformat(row[8]), arrtim=time.fromisoformat(row[9]),
-            arrday=row[10], elptim=timedelta(minutes=row[11]),
+            carrier=row[0],
+            fltno=row[1],
+            depapt=row[2],
+            depcity=row[3],
+            depctry=row[4],
+            arrapt=row[5],
+            arrcity=row[6],
+            arrctry=row[7],
+            deptim=time.fromisoformat(row[8]),
+            arrtim=time.fromisoformat(row[9]),
+            arrday=row[10],
+            elptim=timedelta(minutes=row[11]),
             days=set(DayOfWeek(int(d)) for d in row[12]),
-            govt_app=row[13], comm10_50=row[14],
-            genacft=row[15], inpacft=row[16],
-            service=ServiceType(row[17]), seats=row[18], tons=row[19],
+            govt_app=row[13],
+            comm10_50=row[14],
+            genacft=row[15],
+            inpacft=row[16],
+            service=ServiceType(row[17]),
+            seats=row[18],
+            tons=row[19],
             restrict=row[20],
-            domint=(DomesticInternational(row[21][0]),
-                    DomesticInternational(row[21][1])),
+            domint=(
+                DomesticInternational(row[21][0]),
+                DomesticInternational(row[21][1]),
+            ),
             efffrom=date.fromisoformat(row[22]),
             effto=date.fromisoformat(row[23]),
-            routing=row[24], longest=row[25], distance=row[26],
-            sad=row[27], acft_owner=row[28],
-            operating=row[29], duplicate=row[30], NFlts=row[31]
+            routing=row[24],
+            longest=row[25],
+            distance=row[26],
+            sad=row[27],
+            acft_owner=row[28],
+            operating=row[29],
+            duplicate=row[30],
+            NFlts=row[31],
         )
 
 

--- a/src/parsers/OAG_reader.py
+++ b/src/parsers/OAG_reader.py
@@ -1,0 +1,157 @@
+import csv
+from dataclasses import dataclass
+from enum import Enum
+# TODO: USE PENDULUM?
+from datetime import date, time, timedelta, timezone
+from typing import Generator
+
+
+class DayOfWeek(Enum):
+    MONDAY = 1
+    TUESDAY = 2
+    WEDNESDAY = 3
+    THURSDAY = 4
+    FRIDAY = 5
+    SATURDAY = 6
+    SUNDAY = 7
+
+
+class DomesticInternational(str, Enum):
+    DOMESTIC = 'D'
+    INTERNATIONAL = 'I'
+
+
+class ServiceType(str, Enum):
+    NORMAL_PASSENGER = 'J'
+    PASSENGER_CARGO_IN_CABIN = 'Q'
+    PASSENGER_SHUTTLE_MODE = 'S'
+
+
+# Some information here: https://knowledge.oag.com/docs/schedules-direct-data-fields-explained
+
+@dataclass
+class OAGEntry:
+    carrier: str # 1
+    fltno: int   # 2
+    depapt: str  # 3
+    depcity: str  # 4
+    depctry: str | None # 5
+    arrapt: str  # 6
+    arrcity: str # 7
+    arrctry: str | None # 8
+    deptim: time  # 9
+    arrtim: time  # 10
+    arrday: int # = 0    # -1, 0, +1, +2  TODO: CHECK MEANING # 11
+    elptim: timedelta  # 12
+    days: set[DayOfWeek]  # Set of days of the week (Mon=1, Sun=7) the flight operates # 13
+    # stops       # ALL ZERO  # 14
+    # intapt      # ALL EMPTY # 15
+    # acftchange  # ALL EMPTY # 16
+    govt_app: bool # Whether government approval is required (X OR EMPTY)  # 17
+    comm10_50: int | None # TODO: WHAT'S THIS? EITHER 10 OR EMPTY # 18
+    genacft: str  # TODO: 81 VALUES ⇒ SEPARATE TABLE?  # 19
+    inpacft: str  # TODO: 181 VALUES ⇒ SEPARATE TABLE?  # 20
+    service: ServiceType # 21
+    seats: int # 22
+    tons: float # 23
+    restrict: str | None # TODO: WHAT IS THIS? # 24
+    domint: tuple[DomesticInternational, DomesticInternational] # 25
+    efffrom: date # 26
+    effto: date # 27
+    routing: str # 28
+    longest: bool # "L" or EMPTY # 29
+    distance: int # 30
+    sad: str | None # TODO: WHAT IS THIS? # 31
+    # mcd   # ALL EMPTY # 32
+    # flt_dupe  # ALL EMPTY # 33
+    acft_owner: str | None # 34
+    operating: bool # "O" OR EMPTY  # 35
+    # ghost    # ALL EMPTY # 36
+    duplicate: str | None  # TODO: WHAT IS THIS?  "D", "P" OR EMPTY # 37
+    NFlts: int # 38
+
+    @classmethod
+    def from_csv_row(cls, row: list[str]) -> 'OAGEntry':
+        """
+        Create an OAGEntry instance from a CSV row.
+        """
+
+        days = set()
+        if row[12]:
+            for day in range(1, 8):
+                if str(day) in row[12]:
+                    days.add(DayOfWeek(day))
+
+        def make_int(t: str) -> int:
+            if '.' in t:
+                t = t[:-2]
+            return int(t)
+
+        def make_date(t: str) -> date:
+            tint = make_int(t)
+            # YYYYMMDD
+            return date(tint // 10000, tint % 10000 // 100, tint % 100)
+
+        def make_time(t: str) -> time:
+            tint = make_int(t)
+            return time(tint // 100, tint % 100, tzinfo=timezone.utc)
+
+        def make_timedelta(t: str) -> timedelta:
+            tint = make_int(t)
+            return timedelta(hours=tint // 100, minutes=tint % 100)
+
+        arrday = 0
+        if row[10]:
+            if row[10] == 'P':
+                arrday = -1
+            else:
+                arrday = make_int(row[10])
+
+        return cls(
+            carrier=row[0],
+            fltno=make_int(row[1]),
+            depapt=row[2],
+            depcity=row[3],
+            depctry=row[4] if row[4] else None,
+            arrapt=row[5],
+            arrcity=row[6],
+            arrctry=row[7] if row[7] else None,
+            deptim=make_time(row[8]),
+            arrtim=make_time(row[9]),
+            arrday=arrday,
+            elptim=make_timedelta(row[11]),
+            days=days,
+            govt_app=(row[16].strip().upper() == 'X'),
+            comm10_50=make_int(row[17]) if row[17] else None,
+            genacft=row[18],
+            inpacft=row[19],
+            service=ServiceType(row[20]),
+            seats=make_int(row[21]),
+            tons=float(row[22]),
+            # TODO: ENUM HERE
+            restrict=row[23] if row[23] else None,
+            domint=(DomesticInternational(row[24][0]), DomesticInternational(row[24][1])),
+            efffrom=make_date(row[25]),
+            effto=make_date(row[26]),
+            routing=row[27],
+            longest=(row[28].strip().upper() == 'L'),
+            distance=make_int(row[29]),
+            sad=row[30] if row[30] else None,
+            acft_owner=row[33] if row[33] else None,
+            operating=(row[34].strip().upper() == 'O'),
+            duplicate=row[36] if row[36] else None,
+            NFlts=make_int(row[37])
+        )
+
+
+def read_oag_file(file_path: str) -> Generator[OAGEntry, None, None]:
+    """
+    Reads an OAG CSV file and yields OAGEntry instances for each row.
+    """
+    with open(file_path, newline='') as csvfile:
+        first = True
+        for row in csv.reader(csvfile):
+            if first:
+                first = False
+                continue
+            yield OAGEntry.from_csv_row(row)


### PR DESCRIPTION
**THIS PR IS OBSOLETE AND WILL BE REPLACED BY A NEW ONE. I'LL DELETE IT WHEN THE NEW ONE IS READY.**

**WIP: rough so far.**

Read OAG files, convert them to SQLite database, and get data out of the database in a very simple way.

There are two commands set up:

`convert-oag-data <input-csv-file> <output-sqlite-file>` takes an input OAG CSV file and produces an SQLite3 output file. This reads pre-processed OAG CSV data provided by Prateek. For example:

```
convert-oag-data /home/prateekr/Workbench/AEIC/Processed/OAG_2024_processed_AACES_2050.csv db.sqlite
```

`oag-query <db-file> <condition>...` does very simple queries on the database. For example:

```
oag-query db.sqlite carrier==DL depapt==JFK 'seats>200'
```

The output from `oag-query` is rudimentary, since this is just a demo.

There is an `OAGDatabase` class representing the database. At the moment this just has a single query function that you can pass conditions to, but it's easy enough to write more application-specific things so the query details are encapsulated.

Entries in the OAG database are represented by an `OAGEntry` dataclass. That's not quite finished (again, demo) since there are some fields that could be handled better than they currently are.

Questions:

1. Would it be better for the data conversion tool to work from the original OAG input files? Would it make sense to fold Prateek's pre-processing into the thing that makes the database?
2. What sort of query patterns might there be for this? At the moment, the only query function does simple subsetting, returning full records, i.e., equivalent to full rows in the input CSV file. Are you likely to want anything other than that?
