### PR TITLE
Adjustable legacy builder

### DIFF
--- a/docs/src/trajectories/trajectory_builders.md
+++ b/docs/src/trajectories/trajectory_builders.md
@@ -77,6 +77,118 @@ altitude ($7000\,\text{ft}$ below operating ceiling).
    :members:
 ```
 
+## Adjustable legacy trajectory builder
+
+`AdjustableLegacyBuilder` is a variant of `LegacyBuilder` with the same
+phase-integration logic and the same default behavior, but with additional
+per-flight hooks for changing the assumptions that are normally hard-coded in
+the legacy builder. It is intended for sensitivity studies, policy scenarios,
+or workflows where the basic AEIC v2 trajectory model is still desired but
+where cruise altitude, reserve policy, descent planning, or similar inputs need
+to vary by mission.
+
+With no adjustment arguments, `AdjustableLegacyBuilder` should produce the same
+trajectory as `LegacyBuilder` for the same mission, performance model, and
+builder options.
+
+```python
+import AEIC.trajectories.builders as tb
+
+builder = tb.AdjustableLegacyBuilder(
+    options=tb.Options(iterate_mass=False),
+    legacy_options=tb.LegacyOptions(),
+)
+
+traj = builder.fly(performance_model, mission)
+```
+
+### Adjustment arguments
+
+Adjustments are passed as keyword arguments to `fly`. Each adjustment may be:
+
+- `None`, which uses the standard legacy default;
+- a `float`, which is used directly; or
+- a callable, which receives the current adjustable context, the mission, the
+  performance model, and any adjustment-specific keyword arguments.
+
+The supported adjustment keywords are:
+
+| Keyword | Units | Legacy default |
+| --- | --- | --- |
+| `climb_start_altitude` | m | departure airport altitude + $3000\,\text{ft}$ |
+| `cruise_altitude` | m | aircraft maximum altitude - $7000\,\text{ft}$ |
+| `descent_end_altitude` | m | arrival airport altitude + $3000\,\text{ft}$ |
+| `descent_distance` | m | proportional to `des_start_altitude - des_end_altitude` |
+| `reserve_fuel` | kg | 5% of nominal trip fuel |
+| `divert_distance` | m | 100 NM for flights up to 3 hours, otherwise 200 NM |
+| `hold_time` | s | 45 minutes for flights up to 3 hours, otherwise 30 minutes |
+
+For example, fixed values can be used to pin a scenario:
+
+```python
+traj = builder.fly(
+    performance_model,
+    mission,
+    climb_start_altitude=1500.0,
+    cruise_altitude=9000.0,
+    descent_end_altitude=1200.0,
+    descent_distance=200_000.0,
+    reserve_fuel=1_500.0,
+    divert_distance=150_000.0,
+    hold_time=30 * 60.0,
+)
+```
+
+Callable adjustments are useful when the value depends on mission or aircraft
+properties:
+
+```python
+def cruise_altitude(context, mission, performance):
+    # Fly 1000 m below the aircraft ceiling, but never below the climb start.
+    return max(context.clm_start_altitude, performance.maximum_altitude - 1000.0)
+
+
+def reserve_fuel(context, mission, performance, *, fuel_mass):
+    # Use a larger reserve fraction for this scenario.
+    return 0.10 * fuel_mass
+
+
+traj = builder.fly(
+    performance_model,
+    mission,
+    cruise_altitude=cruise_altitude,
+    reserve_fuel=reserve_fuel,
+)
+```
+
+The fuel-policy callables receive additional keyword-only inputs:
+
+- `reserve_fuel(..., fuel_mass=...)`, where `fuel_mass` is the nominal trip
+  fuel estimate used by the starting-mass calculation;
+- `divert_distance(..., approx_time=...)`, where `approx_time` is the nominal
+  flight time estimate;
+- `hold_time(..., approx_time=...)`, using the same nominal flight time
+  estimate.
+
+### Validation and clamping
+
+The adjustable builder preserves the legacy guardrails where possible:
+
+- a climb start altitude at or above the aircraft ceiling is reset to the
+  departure airport altitude;
+- a cruise altitude below the climb start altitude is raised to the climb start
+  altitude;
+- a cruise altitude above the aircraft ceiling is lowered to the ceiling;
+- a descent end altitude at or above the ceiling is lowered to the ceiling;
+- a descent end altitude above the descent start altitude raises a
+  `ValueError`;
+- a negative descent distance raises a `ValueError`.
+
+```{eval-rst}
+.. automodule:: AEIC.trajectories.builders.adjustable_legacy
+   :members:
+```
+
 ## Work-in-progress builders
 
 The following builders are re-exported from

--- a/src/AEIC/trajectories/builders/__init__.py
+++ b/src/AEIC/trajectories/builders/__init__.py
@@ -1,3 +1,4 @@
+from .adjustable_legacy import AdjustableLegacyBuilder
 from .ads_b import ADSBBuilder, ADSBOptions
 from .base import Builder, Context, Options
 from .dymos import DymosBuilder, DymosOptions
@@ -16,4 +17,5 @@ __all__ = [
     'DymosOptions',
     'LegacyBuilder',
     'LegacyOptions',
+    'AdjustableLegacyBuilder',
 ]

--- a/src/AEIC/trajectories/builders/adjustable_legacy.py
+++ b/src/AEIC/trajectories/builders/adjustable_legacy.py
@@ -175,7 +175,7 @@ class AdjustableLegacyContext(Context):
 
         if self.crz_start_altitude < self.clm_start_altitude:
             raise ValueError(
-                "Departure airport + 3000ft should not be higher"
+                "Departure airport + 3000ft should not be higher "
                 "than start of cruise point"
             )
         if self.des_end_altitude > self.des_start_altitude:
@@ -191,7 +191,7 @@ class AdjustableLegacyContext(Context):
                 descent_distance, mission, ac_performance
             )
         if self.descent_dist_approx < 0:
-            raise ValueError('Arrival airport should not be above cruise altitude')
+            raise ValueError('Descent distance must be non-negative')
 
         # Initialize weather regridding when requested.
         self.weather: Weather | None = None
@@ -241,7 +241,7 @@ class AdjustableLegacyBuilder(Builder):
 
     Args:
         options (Options): Base options for trajectory building.
-        legacy_options (LegactyOptions): Builder-specific options for legacy
+        legacy_options (LegacyOptions): Builder-specific options for legacy
             trajectory builder.
     """
 

--- a/src/AEIC/trajectories/builders/adjustable_legacy.py
+++ b/src/AEIC/trajectories/builders/adjustable_legacy.py
@@ -1,4 +1,8 @@
-from dataclasses import dataclass
+# TODO: Remove this when we move to Python 3.14+.
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Protocol
 
 import numpy as np
 
@@ -19,32 +23,82 @@ from AEIC.weather import Weather
 
 from .. import GroundTrack, Trajectory
 from .base import Builder, Context, Options
+from .legacy import LegacyOptions
 
 
-@dataclass
-class LegacyOptions:
-    """Additional options for the legacy trajectory builder."""
+class AdjustableLegacyContext(Context):
+    """Context for adjustable legacy trajectory builder."""
 
-    altitude_step: float = 1000 * FEET_TO_METERS
-    """Altitude step to use in climb and descent phases (m)."""
+    class AdjustmentFunction(Protocol):
+        """Protocol for context adjustment functions.
 
-    cruise_step: float = 125 * NAUTICAL_MILES_TO_METERS
-    """Ground distance step to use in cruise phase (m)."""
+        An adjustment function takes in the context, mission, performance model
+        possibly additional optional keyword arguments and returns a float
+        value."""
 
-    fuel_LHV: float = 43.8e6
-    """Lower heating value of the fuel used (J/kg)."""
+        def __call__(
+            self,
+            context: AdjustableLegacyContext,
+            mission: Mission,
+            performance: LegacyPerformanceModel,
+            **kwargs,
+        ) -> float: ...
 
-
-class LegacyContext(Context):
-    """Context for legacy trajectory builder."""
+    # A context adjustment is either an adjustment function, a fixed float
+    # value, or None (in which case no adjustment is applied and the behavior
+    # falls back to the standard legacy trajectory builder behavior).
+    ContextAdjustment = AdjustmentFunction | float | None
 
     def __init__(
         self,
-        builder: 'LegacyBuilder',
+        builder: AdjustableLegacyBuilder,
         ac_performance: LegacyPerformanceModel,
         mission: Mission,
         starting_mass: float | None,
+        climb_start_altitude: ContextAdjustment = None,
+        cruise_altitude: ContextAdjustment = None,
+        descent_end_altitude: ContextAdjustment = None,
+        descent_distance: ContextAdjustment = None,
+        reserve_fuel: ContextAdjustment = None,
+        divert_distance: ContextAdjustment = None,
+        hold_time: ContextAdjustment = None,
     ):
+        """Adjustment parameters (a "simple" adjustment is one that takes no
+        additional arguments beyond the context, mission and performance
+        model):
+
+        - `climb_start_altitude`: Simple adjustment for climb start altitude,
+          which defaults to 3000' above departure airport altitude if not
+          provided.
+
+        - `cruise_altitude`: Simple adjustment for cruise altitude, which
+           defaults to 7000' below aircraft operating ceiling if not provided.
+
+        - `descent_end_altitude`: Simple adjustment for descent end altitude,
+           which defaults to 3000' above arrival airport altitude if not
+           provided.
+
+        - `descent_distance`: Simple adjustment for descent distance, which
+           defaults to a value based on the difference between cruise altitude
+           and descent end altitude if not provided.
+
+        - `reserve_fuel`: Adjustment for reserve fuel mass, which defaults to
+           5% of total fuel mass if not provided (additional parameter:
+           `fuel_mass`, total fuel mass consumed based on approximate flight
+           time and nominal fuel flow).
+
+        - `divert_distance`: Adjustment for diversion distance, which defaults
+          to 200 NM if flight time is over 3 hours and 100 NM if flight time is
+          under 3 hours if not provided (additional parameter: `approx_time`,
+          approximate flight time based on distance and nominal cruise speed).
+
+        - `hold_time`: Adjustment for hold time, which defaults to 30 minutes
+          if flight time is over 3 hours and 45 minutes if flight time is under
+          3 hours if not provided (additional parameter: `approx_time`,
+          approximate flight time based on distance and nominal cruise speed).
+
+        """
+
         # The context constructor calculates all of the fixed information used
         # throughout the simulation by the trajectory builder.
 
@@ -67,20 +121,30 @@ class LegacyContext(Context):
             allow_overstep=True,
         )
 
-        # Climb defined as starting 3000' above airport.
-        self.clm_start_altitude = (
-            mission.origin_position.altitude + 3000.0 * FEET_TO_METERS
-        )
+        # Climb defined as starting 3000' above airport (adjustable).
+        if climb_start_altitude is None:
+            self.clm_start_altitude = (
+                mission.origin_position.altitude + 3000.0 * FEET_TO_METERS
+            )
+        else:
+            self.clm_start_altitude = self.apply_adjustment(
+                climb_start_altitude, mission, ac_performance
+            )
 
         # If starting altitude is above operating ceiling, set start altitude
         # to departure airport altitude.
         if self.clm_start_altitude >= ac_performance.maximum_altitude:
             self.clm_start_altitude = mission.origin_position.altitude
 
-        # Cruise altitude is the operating ceiling - 7000 feet.
-        self.crz_start_altitude = (
-            ac_performance.maximum_altitude - 7000.0 * FEET_TO_METERS
-        )
+        # Cruise altitude is the operating ceiling - 7000 feet (adjustable).
+        if cruise_altitude is None:
+            self.crz_start_altitude = (
+                ac_performance.maximum_altitude - 7000.0 * FEET_TO_METERS
+            )
+        else:
+            self.crz_start_altitude = self.apply_adjustment(
+                cruise_altitude, mission, ac_performance
+            )
 
         # Ensure cruise altitude is above the starting altitude.
         if self.crz_start_altitude < self.clm_start_altitude:
@@ -96,10 +160,16 @@ class LegacyContext(Context):
         self.des_start_altitude = self.crz_start_altitude
 
         # Set descent altitude based on 3000' above arrival airport altitude;
-        # clamp to aircraft operating ceiling if needed.
-        self.des_end_altitude = (
-            mission.destination_position.altitude + 3000.0 * FEET_TO_METERS
-        )
+        # clamp to aircraft operating ceiling if needed (adjustable).
+        if descent_end_altitude is None:
+            self.des_end_altitude = (
+                mission.destination_position.altitude + 3000.0 * FEET_TO_METERS
+            )
+        else:
+            self.des_end_altitude = self.apply_adjustment(
+                descent_end_altitude, mission, ac_performance
+            )
+
         if self.des_end_altitude >= ac_performance.maximum_altitude:
             self.des_end_altitude = ac_performance.maximum_altitude
 
@@ -112,9 +182,14 @@ class LegacyContext(Context):
             raise ValueError(
                 "Arrival airport + 3000ft should not be higher than end of cruise point"
             )
-        self.descent_dist_approx = 18.228347 * (
-            self.des_start_altitude - self.des_end_altitude
-        )
+        if descent_distance is None:
+            self.descent_dist_approx = 18.228347 * (
+                self.des_start_altitude - self.des_end_altitude
+            )
+        else:
+            self.descent_dist_approx = self.apply_adjustment(
+                descent_distance, mission, ac_performance
+            )
         if self.descent_dist_approx < 0:
             raise ValueError('Arrival airport should not be above cruise altitude')
 
@@ -128,6 +203,12 @@ class LegacyContext(Context):
                 file_format=config.weather.file_format,
             )
 
+        # Save reserve fuel, divert distance and hold time adjustments for use
+        # in starting mass calculation.
+        self.reserve_fuel = reserve_fuel
+        self.divert_distance = divert_distance
+        self.hold_time = hold_time
+
         # Pass information to base context class constructor.
         super().__init__(
             builder,
@@ -138,8 +219,23 @@ class LegacyContext(Context):
             starting_mass=starting_mass,
         )
 
+    def apply_adjustment(
+        self,
+        adjustment: ContextAdjustment,
+        mission: Mission,
+        performance: LegacyPerformanceModel,
+        **kwargs,
+    ) -> float:
+        """Helper function to apply a context adjustment."""
+        if adjustment is None:
+            raise RuntimeError('Attempting to apply an empty ContextAdjustment.')
+        elif isinstance(adjustment, Callable):
+            return adjustment(self, mission, performance, **kwargs)
+        else:
+            return adjustment
 
-class LegacyBuilder(Builder):
+
+class AdjustableLegacyBuilder(Builder):
     """Model for determining flight trajectories using the legacy method
     from AEIC v2.
 
@@ -149,7 +245,7 @@ class LegacyBuilder(Builder):
             trajectory builder.
     """
 
-    CONTEXT_CLASS = LegacyContext
+    CONTEXT_CLASS = AdjustableLegacyContext
 
     def __init__(
         self,
@@ -210,15 +306,42 @@ class LegacyBuilder(Builder):
         fuel_mass = approx_time * perf.fuel_flow
 
         # Reserve fuel (assumed 5%).
-        reserve_mass = fuel_mass * 0.05
+        if self.reserve_fuel is None:
+            reserve_mass = fuel_mass * 0.05
+        else:
+            reserve_mass = self.apply_adjustment(
+                self.reserve_fuel,
+                self.mission,
+                self.ac_performance,
+                fuel_mass=fuel_mass,
+            )
 
         # Diversion and hold fuel per AEIC v2.
-        if approx_time > 180 * MINUTES_TO_SECONDS:
-            divert_dist = 200.0 * NAUTICAL_MILES_TO_METERS
-            hold_time = 30 * MINUTES_TO_SECONDS
+        # TODO: ADJUSTMENT POINT
+        if self.divert_distance is None:
+            if approx_time > 180 * MINUTES_TO_SECONDS:
+                divert_dist = 200.0 * NAUTICAL_MILES_TO_METERS
+            else:
+                divert_dist = 100.0 * NAUTICAL_MILES_TO_METERS
         else:
-            divert_dist = 100.0 * NAUTICAL_MILES_TO_METERS
-            hold_time = 45 * MINUTES_TO_SECONDS
+            divert_dist = self.apply_adjustment(
+                self.divert_distance,
+                self.mission,
+                self.ac_performance,
+                approx_time=approx_time,
+            )
+        if self.hold_time is None:
+            if approx_time > 180 * MINUTES_TO_SECONDS:
+                hold_time = 30 * MINUTES_TO_SECONDS
+            else:
+                hold_time = 45 * MINUTES_TO_SECONDS
+        else:
+            hold_time = self.apply_adjustment(
+                self.hold_time,
+                self.mission,
+                self.ac_performance,
+                approx_time=approx_time,
+            )
         divert_mass = divert_dist / perf.true_airspeed * perf.fuel_flow
         hold_mass = hold_time * perf_low.fuel_flow
 
@@ -267,7 +390,8 @@ class LegacyBuilder(Builder):
             SimpleFlightRules.DESCEND,
             self.des_end_altitude,
         )
-        traj.n_descent -= 1
+        if traj.n_descent > 0:
+            traj.n_descent -= 1
 
     def _fly_level_change(
         self,
@@ -300,6 +424,8 @@ class LegacyBuilder(Builder):
             if flight_phase == FlightPhase.CLIMB
             else -self.altitude_step,
         )
+        if len(altitudes) == 0:
+            return
         if (flight_phase == FlightPhase.CLIMB and altitudes[-1] < final_altitude) or (
             flight_phase == FlightPhase.DESCENT and altitudes[-1] > final_altitude
         ):
@@ -373,6 +499,7 @@ class LegacyBuilder(Builder):
 
                     # NOTE: I have no idea where AEIC v2 got the efficiency of
                     # 0.15 from.
+                    # TODO: ADJUSTMENT POINT
                     efficiency = 0.15
                     accel_fuel = kinetic_energy_chg / self.fuel_LHV / efficiency
                     seg_fuel += accel_fuel

--- a/src/AEIC/trajectories/builders/base.py
+++ b/src/AEIC/trajectories/builders/base.py
@@ -234,8 +234,10 @@ class Builder(ABC):
             raise
         finally:
             # Remove the context: this only exists during the simulation of a
-            # trajectory.
-            del self.ctx
+            # trajectory. Context construction itself can fail, so only delete
+            # it if assignment succeeded.
+            if hasattr(self, 'ctx'):
+                del self.ctx
 
     def _iterate_mass(self) -> Trajectory:
         """Iterate on starting mass to minimize residual fuel mass."""

--- a/tests/test_adjustable_legacy_builder.py
+++ b/tests/test_adjustable_legacy_builder.py
@@ -1,0 +1,249 @@
+import numpy as np
+import pytest
+
+import AEIC.trajectories.builders as tb
+from AEIC.performance.models.legacy import ROCDFilter
+from AEIC.performance.types import AircraftState, SimpleFlightRules
+from AEIC.trajectories import GroundTrack
+from AEIC.trajectories.builders.adjustable_legacy import AdjustableLegacyContext
+from AEIC.units import FL_TO_METERS
+
+
+def _ground_track(mission):
+    return GroundTrack.great_circle(
+        mission.origin_position.location,
+        mission.destination_position.location,
+        allow_overstep=True,
+    )
+
+
+def _expected_starting_mass(
+    performance_model,
+    mission,
+    cruise_altitude,
+    reserve_fuel,
+    divert_distance,
+    hold_time,
+):
+    perf = performance_model.evaluate(
+        AircraftState(altitude=cruise_altitude, aircraft_mass='max'),
+        SimpleFlightRules.CRUISE,
+    )
+    lowest_cruise_altitude = (
+        min(performance_model.performance_table(ROCDFilter.ZERO).fl) * FL_TO_METERS
+    )
+    perf_low = performance_model.evaluate(
+        AircraftState(altitude=lowest_cruise_altitude, aircraft_mass='min'),
+        SimpleFlightRules.CRUISE,
+    )
+
+    approx_time = _ground_track(mission).total_distance / perf.true_airspeed
+    fuel_mass = approx_time * perf.fuel_flow
+    payload_mass = performance_model.maximum_payload * mission.load_factor
+    divert_mass = divert_distance / perf.true_airspeed * perf.fuel_flow
+    hold_mass = hold_time * perf_low.fuel_flow
+
+    return min(
+        performance_model.empty_mass
+        + payload_mass
+        + fuel_mass
+        + reserve_fuel
+        + divert_mass
+        + hold_mass,
+        performance_model.maximum_mass,
+    )
+
+
+def test_adjustable_legacy_without_adjustments_matches_legacy(
+    sample_missions, performance_model
+):
+    mission = sample_missions[0]
+    options = tb.Options(iterate_mass=False)
+
+    legacy_traj = tb.LegacyBuilder(options=options).fly(performance_model, mission)
+    adjustable_traj = tb.AdjustableLegacyBuilder(options=options).fly(
+        performance_model, mission
+    )
+
+    assert adjustable_traj.approx_eq(legacy_traj)
+    assert adjustable_traj.starting_mass == pytest.approx(legacy_traj.starting_mass)
+    assert adjustable_traj.total_fuel_mass == pytest.approx(legacy_traj.total_fuel_mass)
+    assert adjustable_traj.n_climb == legacy_traj.n_climb
+    assert adjustable_traj.n_cruise == legacy_traj.n_cruise
+    assert adjustable_traj.n_descent == legacy_traj.n_descent
+
+
+def test_fixed_geometry_adjustments_shape_trajectory(
+    sample_missions, performance_model
+):
+    mission = sample_missions[0]
+    descent_distance = 200_000.0
+
+    traj = tb.AdjustableLegacyBuilder(options=tb.Options(iterate_mass=False)).fly(
+        performance_model,
+        mission,
+        climb_start_altitude=1500.0,
+        cruise_altitude=9000.0,
+        descent_end_altitude=1200.0,
+        descent_distance=descent_distance,
+    )
+
+    assert traj.altitude[0] == pytest.approx(1500.0)
+    assert np.max(traj.altitude) == pytest.approx(9000.0)
+    assert traj.altitude[-1] == pytest.approx(1200.0)
+
+    descent_start_idx = np.flatnonzero(np.diff(traj.altitude) < 0)[0]
+    expected_descent_start = _ground_track(mission).total_distance - descent_distance
+    assert traj.ground_distance[descent_start_idx] == pytest.approx(
+        expected_descent_start
+    )
+
+
+def test_fixed_fuel_policy_adjustments_set_starting_mass(
+    sample_missions, performance_model
+):
+    mission = sample_missions[0]
+    cruise_altitude = 9000.0
+    reserve_fuel = 1234.0
+    divert_distance = 150_000.0
+    hold_time = 1200.0
+
+    traj = tb.AdjustableLegacyBuilder(options=tb.Options(iterate_mass=False)).fly(
+        performance_model,
+        mission,
+        cruise_altitude=cruise_altitude,
+        reserve_fuel=reserve_fuel,
+        divert_distance=divert_distance,
+        hold_time=hold_time,
+    )
+
+    assert traj.starting_mass == pytest.approx(
+        _expected_starting_mass(
+            performance_model,
+            mission,
+            cruise_altitude,
+            reserve_fuel,
+            divert_distance,
+            hold_time,
+        )
+    )
+
+
+def test_callable_adjustments_receive_context_and_kwargs(
+    sample_missions, performance_model
+):
+    mission = sample_missions[0]
+    calls = []
+
+    def adjustment(name, value):
+        def _adjust(context, mission_arg, performance_arg, **kwargs):
+            calls.append((name, context, mission_arg, performance_arg, kwargs))
+            return value
+
+        return _adjust
+
+    reserve_fuel = 1234.0
+    divert_distance = 150_000.0
+    hold_time = 1200.0
+    cruise_altitude = 9000.0
+
+    traj = tb.AdjustableLegacyBuilder(options=tb.Options(iterate_mass=False)).fly(
+        performance_model,
+        mission,
+        climb_start_altitude=adjustment('climb_start_altitude', 1500.0),
+        cruise_altitude=adjustment('cruise_altitude', cruise_altitude),
+        descent_end_altitude=adjustment('descent_end_altitude', 1200.0),
+        descent_distance=adjustment('descent_distance', 200_000.0),
+        reserve_fuel=adjustment('reserve_fuel', reserve_fuel),
+        divert_distance=adjustment('divert_distance', divert_distance),
+        hold_time=adjustment('hold_time', hold_time),
+    )
+
+    call_by_name = {name: call for name, *call in calls}
+    assert set(call_by_name) == {
+        'climb_start_altitude',
+        'cruise_altitude',
+        'descent_end_altitude',
+        'descent_distance',
+        'reserve_fuel',
+        'divert_distance',
+        'hold_time',
+    }
+
+    for context, mission_arg, performance_arg, _ in call_by_name.values():
+        assert isinstance(context, AdjustableLegacyContext)
+        assert mission_arg is mission
+        assert performance_arg is performance_model
+
+    assert call_by_name['climb_start_altitude'][3] == {}
+    assert call_by_name['cruise_altitude'][3] == {}
+    assert call_by_name['descent_end_altitude'][3] == {}
+    assert call_by_name['descent_distance'][3] == {}
+    assert set(call_by_name['reserve_fuel'][3]) == {'fuel_mass'}
+    assert set(call_by_name['divert_distance'][3]) == {'approx_time'}
+    assert set(call_by_name['hold_time'][3]) == {'approx_time'}
+
+    assert traj.altitude[0] == pytest.approx(1500.0)
+    assert traj.starting_mass == pytest.approx(
+        _expected_starting_mass(
+            performance_model,
+            mission,
+            cruise_altitude,
+            reserve_fuel,
+            divert_distance,
+            hold_time,
+        )
+    )
+
+
+@pytest.mark.parametrize(
+    'kwargs,expected_altitude',
+    [
+        pytest.param(
+            {'climb_start_altitude': 2000.0, 'cruise_altitude': 1000.0},
+            2000.0,
+            id='cruise_below_climb_clamps_to_climb',
+        ),
+        pytest.param(
+            {'cruise_altitude': 20_000.0},
+            None,
+            id='cruise_above_ceiling_clamps_to_ceiling',
+        ),
+    ],
+)
+def test_adjustment_altitude_clamps(
+    sample_missions, performance_model, kwargs, expected_altitude
+):
+    mission = sample_missions[0]
+    if expected_altitude is None:
+        expected_altitude = performance_model.maximum_altitude
+
+    traj = tb.AdjustableLegacyBuilder(options=tb.Options(iterate_mass=False)).fly(
+        performance_model, mission, **kwargs
+    )
+
+    assert np.max(traj.altitude) == pytest.approx(expected_altitude)
+
+
+@pytest.mark.parametrize(
+    'kwargs,match',
+    [
+        pytest.param(
+            {'cruise_altitude': 9000.0, 'descent_end_altitude': 10_000.0},
+            'Arrival airport \\+ 3000ft',
+            id='descent_end_above_descent_start_raises',
+        ),
+        pytest.param(
+            {'descent_distance': -1.0},
+            'Arrival airport should not be above cruise altitude',
+            id='negative_descent_distance_raises',
+        ),
+    ],
+)
+def test_invalid_adjustments_raise_value_error(
+    sample_missions, performance_model, kwargs, match
+):
+    with pytest.raises(ValueError, match=match):
+        tb.AdjustableLegacyBuilder(options=tb.Options(iterate_mass=False)).fly(
+            performance_model, sample_missions[0], **kwargs
+        )

--- a/tests/test_adjustable_legacy_builder.py
+++ b/tests/test_adjustable_legacy_builder.py
@@ -235,7 +235,7 @@ def test_adjustment_altitude_clamps(
         ),
         pytest.param(
             {'descent_distance': -1.0},
-            'Arrival airport should not be above cruise altitude',
+            'Descent distance must be non-negative',
             id='negative_descent_distance_raises',
         ),
     ],


### PR DESCRIPTION
Adds a new trajectory builder type, `AdjustableLegacyBuilder`. This defaults to the same behavior as the main legacy builder intended to replicate MATLAB AEIC v2 behavior, but it exposes a number of hooks to adjust various aspects of the trajectory simulation.