### PR TITLE
Fuel burn indexing was one index ahead

### DIFF
--- a/src/AEIC/emissions/emission.py
+++ b/src/AEIC/emissions/emission.py
@@ -86,11 +86,7 @@ class Emissions:
     FIELD_SETS: ClassVar[list[FieldSet]] = [EMISSIONS_FIELDS]
 
     trajectory_emissions: SpeciesValues[np.ndarray]
-    """Per-segment emissions along the trajectory for each species [g].
-
-    Element ``i`` belongs to the segment from trajectory point ``i`` to
-    ``i + 1``. The final element is zero.
-    """
+    """Per-segment emissions along the trajectory for each species [g]."""
 
     trajectory_indices: SpeciesValues[np.ndarray]
     """Per-segment emission indices along the trajectory for each species."""
@@ -171,7 +167,8 @@ def compute_emissions(
     object."""
 
     # Calculate cruise trajectory emissions (CO₂, H₂O, SOₓ, NOₓ, HC, CO, nvPM).
-    fuel_burn_per_segment = segment_fuel_burn(traj.fuel_mass)
+    fuel_burn_per_segment = np.zeros_like(traj.fuel_mass)
+    fuel_burn_per_segment[:-1] = traj.fuel_mass[:-1] - traj.fuel_mass[1:]
     trajectory = get_trajectory_emissions(pm, traj, fuel_burn_per_segment, fuel)
     total_fuel_burn = trajectory.fuel_burn
 
@@ -223,17 +220,6 @@ def compute_emissions(
         emissions.lifecycle_co2 = lifecycle_adjustment
 
     return emissions
-
-
-def segment_fuel_burn(fuel_mass: np.ndarray) -> np.ndarray:
-    """Return fuel burn indexed by the point where each segment starts.
-
-    Element ``i`` belongs to the segment from point ``i`` to point ``i + 1``.
-    The final element is zero because no segment starts at the final point.
-    """
-    fuel_burn = np.zeros_like(fuel_mass)
-    fuel_burn[:-1] = fuel_mass[:-1] - fuel_mass[1:]
-    return fuel_burn
 
 
 def sum_total_emissions(

--- a/src/AEIC/emissions/emission.py
+++ b/src/AEIC/emissions/emission.py
@@ -86,7 +86,11 @@ class Emissions:
     FIELD_SETS: ClassVar[list[FieldSet]] = [EMISSIONS_FIELDS]
 
     trajectory_emissions: SpeciesValues[np.ndarray]
-    """Per-segment emissions along the trajectory for each species [g]."""
+    """Per-segment emissions along the trajectory for each species [g].
+
+    Element ``i`` belongs to the segment from trajectory point ``i`` to
+    ``i + 1``. The final element is zero.
+    """
 
     trajectory_indices: SpeciesValues[np.ndarray]
     """Per-segment emission indices along the trajectory for each species."""
@@ -167,8 +171,7 @@ def compute_emissions(
     object."""
 
     # Calculate cruise trajectory emissions (CO₂, H₂O, SOₓ, NOₓ, HC, CO, nvPM).
-    fuel_burn_per_segment = np.zeros_like(traj.fuel_mass)
-    fuel_burn_per_segment[1:] = traj.fuel_mass[:-1] - traj.fuel_mass[1:]
+    fuel_burn_per_segment = segment_fuel_burn(traj.fuel_mass)
     trajectory = get_trajectory_emissions(pm, traj, fuel_burn_per_segment, fuel)
     total_fuel_burn = trajectory.fuel_burn
 
@@ -220,6 +223,17 @@ def compute_emissions(
         emissions.lifecycle_co2 = lifecycle_adjustment
 
     return emissions
+
+
+def segment_fuel_burn(fuel_mass: np.ndarray) -> np.ndarray:
+    """Return fuel burn indexed by the point where each segment starts.
+
+    Element ``i`` belongs to the segment from point ``i`` to point ``i + 1``.
+    The final element is zero because no segment starts at the final point.
+    """
+    fuel_burn = np.zeros_like(fuel_mass)
+    fuel_burn[:-1] = fuel_mass[:-1] - fuel_mass[1:]
+    return fuel_burn
 
 
 def sum_total_emissions(

--- a/src/AEIC/emissions/trajectory.py
+++ b/src/AEIC/emissions/trajectory.py
@@ -179,6 +179,7 @@ def _trajectory_slice(traj: Trajectory) -> slice:
     if config.emissions.climb_descent_mode != ClimbDescentMode.TRAJECTORY:
         # Climb and descent segments are handled in the LTO emissions
         # calculations.
-        return slice(traj.n_climb, len(traj) - traj.n_descent)
+        cruise_start = traj.n_climb - 1
+        return slice(cruise_start, cruise_start + traj.n_cruise)
     else:
         return slice(0, len(traj))

--- a/src/AEIC/emissions/trajectory.py
+++ b/src/AEIC/emissions/trajectory.py
@@ -178,8 +178,7 @@ def _calculate_EI_nvPM(
 def _trajectory_slice(traj: Trajectory) -> slice:
     if config.emissions.climb_descent_mode != ClimbDescentMode.TRAJECTORY:
         # Climb and descent segments are handled in the LTO emissions
-        # calculations.
-        cruise_start = traj.n_climb - 1
-        return slice(cruise_start, cruise_start + traj.n_cruise)
+        # calculations. Segment data belong to the segment's starting point.
+        return slice(traj.n_climb - 1, traj.n_climb - 1 + traj.n_cruise)
     else:
         return slice(0, len(traj))

--- a/tests/test_emissions.py
+++ b/tests/test_emissions.py
@@ -9,6 +9,7 @@ from AEIC.config.emissions import ClimbDescentMode
 from AEIC.emissions import compute_emissions
 from AEIC.emissions.ei.hcco import EI_HCCO
 from AEIC.emissions.ei.nox import BFFM2_EINOx, NOx_speciation
+from AEIC.emissions.emission import segment_fuel_burn
 from AEIC.emissions.gse import get_GSE_emissions
 from AEIC.emissions.trajectory import (
     _calculate_EI_nvPM,
@@ -128,6 +129,47 @@ def test_emissions_species(emissions):
     species and added a stray duplicate.
     """
     assert emissions.species == set(Species)
+
+
+def testsegment_fuel_burn_is_start_indexed_and_conservative():
+    """Segment fuel belongs to its start point and conserves total fuel."""
+    rng = np.random.default_rng(42)
+
+    for npoints in range(2, 20):
+        expected_burn = rng.uniform(0.01, 100.0, npoints - 1)
+        fuel_mass = 10_000.0 - np.concatenate(([0.0], np.cumsum(expected_burn)))
+
+        actual = segment_fuel_burn(fuel_mass)
+
+        np.testing.assert_allclose(actual[:-1], expected_burn)
+        assert actual[-1] == 0.0
+        assert np.sum(actual) == pytest.approx(fuel_mass[0] - fuel_mass[-1])
+
+
+@pytest.mark.config_updates(
+    emissions__climb_descent_mode=ClimbDescentMode.TRAJECTORY,
+    emissions__lifecycle_enabled=False,
+)
+def test_trajectory_emissions_use_segment_start_index(perf_model, fuel, trajectory):
+    """A sharp EI change distinguishes start-point from endpoint indexing."""
+    trajectory._npoints = 3
+    trajectory.n_climb = trajectory.n_cruise = trajectory.n_descent = 1
+    trajectory.fuel_mass = np.array([100.0, 91.0, 89.0])
+    trajectory.fuel_flow = np.array([0.30, 0.55, 0.32])
+    trajectory.altitude = trajectory.altitude[:3]
+    trajectory.rate_of_climb = trajectory.rate_of_climb[:3]
+    trajectory.true_airspeed = trajectory.true_airspeed[:3]
+
+    output = compute_emissions(perf_model, fuel, trajectory)
+
+    np.testing.assert_allclose(output.fuel_burn_per_segment, [9.0, 2.0, 0.0])
+    hc_indices = output.trajectory_indices[Species.HC]
+    expected = np.array([9.0 * hc_indices[0], 2.0 * hc_indices[1], 0.0])
+    endpoint_indexed_total = 9.0 * hc_indices[1] + 2.0 * hc_indices[2]
+
+    np.testing.assert_allclose(output.trajectory_emissions[Species.HC], expected)
+    assert np.sum(expected) != pytest.approx(endpoint_indexed_total)
+    assert np.sum(output.fuel_burn_per_segment) == pytest.approx(11.0)
 
 
 def _expected_trajectory_indices(perf_model, trajectory):

--- a/tests/test_emissions.py
+++ b/tests/test_emissions.py
@@ -5,6 +5,7 @@ import math
 import numpy as np
 import pytest
 
+import AEIC.trajectories.builders as tb
 from AEIC.config.emissions import ClimbDescentMode
 from AEIC.emissions import compute_emissions
 from AEIC.emissions.ei.hcco import EI_HCCO
@@ -131,7 +132,7 @@ def test_emissions_species(emissions):
     assert emissions.species == set(Species)
 
 
-def testsegment_fuel_burn_is_start_indexed_and_conservative():
+def test_segment_fuel_burn_is_start_indexed_and_conservative():
     """Segment fuel belongs to its start point and conserves total fuel."""
     rng = np.random.default_rng(42)
 
@@ -391,13 +392,45 @@ def test_lto_respects_traj_flag_false(perf_model, fuel, trajectory):
         assert any(
             output.lto_emissions[species][m] > 0 for species in output.lto_emissions
         )
-    climb_slice = slice(0, trajectory.n_climb)
-    cruise_slice = slice(trajectory.n_climb, len(trajectory) - trajectory.n_descent)
-    descent_slice = slice(len(trajectory) - trajectory.n_descent, len(trajectory))
+    cruise_start = trajectory.n_climb - 1
+    cruise_stop = cruise_start + trajectory.n_cruise
+    climb_slice = slice(0, cruise_start)
+    cruise_slice = slice(cruise_start, cruise_stop)
+    descent_slice = slice(cruise_stop, len(trajectory))
     for species, arr in output.trajectory_emissions.items():
         assert np.sum(arr[cruise_slice]) > 0
         assert np.allclose(arr[climb_slice], 0)
         assert np.allclose(arr[descent_slice], 0)
+
+
+@pytest.mark.config_updates(
+    emissions__climb_descent_mode=ClimbDescentMode.LTO,
+    emissions__lifecycle_enabled=False,
+)
+@pytest.mark.parametrize(
+    'builder_type',
+    [tb.LegacyBuilder, tb.AdjustableLegacyBuilder],
+)
+def test_lto_trajectory_emissions_match_physical_cruise_segments(
+    builder_type, sample_missions, performance_model, fuel
+):
+    """LTO mode retains exactly the level-flight physical segments.
+
+    Rate of climb is stored at each segment's start point, so this is an
+    independent physical oracle for cruise ownership rather than a repetition
+    of ``_trajectory_slice``.
+    """
+    traj = builder_type(options=tb.Options(iterate_mass=False)).fly(
+        performance_model, sample_missions[0]
+    )
+    output = compute_emissions(performance_model, fuel, traj)
+
+    expected_cruise = np.isclose(traj.rate_of_climb[:-1], 0.0)
+    actual_nonzero = output.trajectory_emissions[Species.CO2][:-1] > 0.0
+
+    np.testing.assert_array_equal(actual_nonzero, expected_cruise)
+    assert np.count_nonzero(actual_nonzero) == traj.n_cruise
+    assert output.trajectory_emissions[Species.CO2][-1] == 0.0
 
 
 def test_lto_nox_split_consistent_with_speciation_factors(emissions):

--- a/tests/test_emissions.py
+++ b/tests/test_emissions.py
@@ -5,12 +5,10 @@ import math
 import numpy as np
 import pytest
 
-import AEIC.trajectories.builders as tb
 from AEIC.config.emissions import ClimbDescentMode
 from AEIC.emissions import compute_emissions
 from AEIC.emissions.ei.hcco import EI_HCCO
 from AEIC.emissions.ei.nox import BFFM2_EINOx, NOx_speciation
-from AEIC.emissions.emission import segment_fuel_burn
 from AEIC.emissions.gse import get_GSE_emissions
 from AEIC.emissions.trajectory import (
     _calculate_EI_nvPM,
@@ -130,47 +128,6 @@ def test_emissions_species(emissions):
     species and added a stray duplicate.
     """
     assert emissions.species == set(Species)
-
-
-def test_segment_fuel_burn_is_start_indexed_and_conservative():
-    """Segment fuel belongs to its start point and conserves total fuel."""
-    rng = np.random.default_rng(42)
-
-    for npoints in range(2, 20):
-        expected_burn = rng.uniform(0.01, 100.0, npoints - 1)
-        fuel_mass = 10_000.0 - np.concatenate(([0.0], np.cumsum(expected_burn)))
-
-        actual = segment_fuel_burn(fuel_mass)
-
-        np.testing.assert_allclose(actual[:-1], expected_burn)
-        assert actual[-1] == 0.0
-        assert np.sum(actual) == pytest.approx(fuel_mass[0] - fuel_mass[-1])
-
-
-@pytest.mark.config_updates(
-    emissions__climb_descent_mode=ClimbDescentMode.TRAJECTORY,
-    emissions__lifecycle_enabled=False,
-)
-def test_trajectory_emissions_use_segment_start_index(perf_model, fuel, trajectory):
-    """A sharp EI change distinguishes start-point from endpoint indexing."""
-    trajectory._npoints = 3
-    trajectory.n_climb = trajectory.n_cruise = trajectory.n_descent = 1
-    trajectory.fuel_mass = np.array([100.0, 91.0, 89.0])
-    trajectory.fuel_flow = np.array([0.30, 0.55, 0.32])
-    trajectory.altitude = trajectory.altitude[:3]
-    trajectory.rate_of_climb = trajectory.rate_of_climb[:3]
-    trajectory.true_airspeed = trajectory.true_airspeed[:3]
-
-    output = compute_emissions(perf_model, fuel, trajectory)
-
-    np.testing.assert_allclose(output.fuel_burn_per_segment, [9.0, 2.0, 0.0])
-    hc_indices = output.trajectory_indices[Species.HC]
-    expected = np.array([9.0 * hc_indices[0], 2.0 * hc_indices[1], 0.0])
-    endpoint_indexed_total = 9.0 * hc_indices[1] + 2.0 * hc_indices[2]
-
-    np.testing.assert_allclose(output.trajectory_emissions[Species.HC], expected)
-    assert np.sum(expected) != pytest.approx(endpoint_indexed_total)
-    assert np.sum(output.fuel_burn_per_segment) == pytest.approx(11.0)
 
 
 def _expected_trajectory_indices(perf_model, trajectory):
@@ -401,36 +358,6 @@ def test_lto_respects_traj_flag_false(perf_model, fuel, trajectory):
         assert np.sum(arr[cruise_slice]) > 0
         assert np.allclose(arr[climb_slice], 0)
         assert np.allclose(arr[descent_slice], 0)
-
-
-@pytest.mark.config_updates(
-    emissions__climb_descent_mode=ClimbDescentMode.LTO,
-    emissions__lifecycle_enabled=False,
-)
-@pytest.mark.parametrize(
-    'builder_type',
-    [tb.LegacyBuilder, tb.AdjustableLegacyBuilder],
-)
-def test_lto_trajectory_emissions_match_physical_cruise_segments(
-    builder_type, sample_missions, performance_model, fuel
-):
-    """LTO mode retains exactly the level-flight physical segments.
-
-    Rate of climb is stored at each segment's start point, so this is an
-    independent physical oracle for cruise ownership rather than a repetition
-    of ``_trajectory_slice``.
-    """
-    traj = builder_type(options=tb.Options(iterate_mass=False)).fly(
-        performance_model, sample_missions[0]
-    )
-    output = compute_emissions(performance_model, fuel, traj)
-
-    expected_cruise = np.isclose(traj.rate_of_climb[:-1], 0.0)
-    actual_nonzero = output.trajectory_emissions[Species.CO2][:-1] > 0.0
-
-    np.testing.assert_array_equal(actual_nonzero, expected_cruise)
-    assert np.count_nonzero(actual_nonzero) == traj.n_cruise
-    assert output.trajectory_emissions[Species.CO2][-1] == 0.0
 
 
 def test_lto_nox_split_consistent_with_speciation_factors(emissions):

--- a/tests/test_gridding.py
+++ b/tests/test_gridding.py
@@ -10,13 +10,16 @@ import zarr
 
 from AEIC.commands.trajectories_to_grid import (
     _read_and_validate_zarr_metadata,
+    map_phase,
     reduce_phase,
 )
 from AEIC.config import config
+from AEIC.emissions.emission import EMISSIONS_FIELDS
 from AEIC.gridding.grid import Grid, ISAPressureGrid
 from AEIC.missions import Filter
 from AEIC.storage.reproducibility import ReproducibilityData
-from AEIC.types import Species
+from AEIC.types import Species, SpeciesValues
+from tests.utils import make_test_trajectory
 
 
 def test_height_grid_load():
@@ -49,6 +52,60 @@ def test_pressure_grid_load():
     edges = grid.altitude.edges
     assert len(edges) == 8
     assert np.all(np.diff(edges) > 0)  # ascending
+
+
+@pytest.mark.parametrize(
+    ('longitude', 'latitude', 'altitude', 'segment_emissions'),
+    [
+        (
+            [-10.0, -8.0, -6.0],
+            [10.0, 11.0, 12.0],
+            [1000.0, 2500.0, 4000.0],
+            [25.0, 75.0, 0.0],
+        ),
+        (
+            [179.0, -179.0],
+            [10.0, 11.0],
+            [1000.0, 2000.0],
+            [100.0, 0.0],
+        ),
+    ],
+    ids=['ordinary', 'dateline'],
+)
+def test_map_phase_conserves_start_indexed_segment_emissions(
+    tmp_path,
+    longitude,
+    latitude,
+    altitude,
+    segment_emissions,
+):
+    """Trajectory-to-grid mapping conserves ordinary and date-line segments."""
+    npoints = len(longitude)
+    traj = make_test_trajectory(npoints, seed=41)
+    traj.longitude = np.asarray(longitude)
+    traj.latitude = np.asarray(latitude)
+    traj.altitude = np.asarray(altitude)
+    traj.add_fields(EMISSIONS_FIELDS)
+    traj.trajectory_emissions = SpeciesValues[np.ndarray](
+        {Species.CO2: np.asarray(segment_emissions)}
+    )
+
+    grid = Grid.load(config.file_location('grids/basic-4x4.toml'))
+    map_output = tmp_path / 'mapped.zarr'
+    map_phase(
+        ntrajs=1,
+        species=[Species.CO2],
+        traj_iter=iter([traj]),
+        grid=grid,
+        map_output=str(map_output),
+    )
+
+    mapped = zarr.open_array(store=str(map_output), mode='r')
+    np.testing.assert_allclose(
+        np.sum(mapped[..., 0]),
+        np.sum(segment_emissions[:-1]),
+        rtol=1e-6,
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_gridding.py
+++ b/tests/test_gridding.py
@@ -10,16 +10,13 @@ import zarr
 
 from AEIC.commands.trajectories_to_grid import (
     _read_and_validate_zarr_metadata,
-    map_phase,
     reduce_phase,
 )
 from AEIC.config import config
-from AEIC.emissions.emission import EMISSIONS_FIELDS
 from AEIC.gridding.grid import Grid, ISAPressureGrid
 from AEIC.missions import Filter
 from AEIC.storage.reproducibility import ReproducibilityData
-from AEIC.types import Species, SpeciesValues
-from tests.utils import make_test_trajectory
+from AEIC.types import Species
 
 
 def test_height_grid_load():
@@ -52,60 +49,6 @@ def test_pressure_grid_load():
     edges = grid.altitude.edges
     assert len(edges) == 8
     assert np.all(np.diff(edges) > 0)  # ascending
-
-
-@pytest.mark.parametrize(
-    ('longitude', 'latitude', 'altitude', 'segment_emissions'),
-    [
-        (
-            [-10.0, -8.0, -6.0],
-            [10.0, 11.0, 12.0],
-            [1000.0, 2500.0, 4000.0],
-            [25.0, 75.0, 0.0],
-        ),
-        (
-            [179.0, -179.0],
-            [10.0, 11.0],
-            [1000.0, 2000.0],
-            [100.0, 0.0],
-        ),
-    ],
-    ids=['ordinary', 'dateline'],
-)
-def test_map_phase_conserves_start_indexed_segment_emissions(
-    tmp_path,
-    longitude,
-    latitude,
-    altitude,
-    segment_emissions,
-):
-    """Trajectory-to-grid mapping conserves ordinary and date-line segments."""
-    npoints = len(longitude)
-    traj = make_test_trajectory(npoints, seed=41)
-    traj.longitude = np.asarray(longitude)
-    traj.latitude = np.asarray(latitude)
-    traj.altitude = np.asarray(altitude)
-    traj.add_fields(EMISSIONS_FIELDS)
-    traj.trajectory_emissions = SpeciesValues[np.ndarray](
-        {Species.CO2: np.asarray(segment_emissions)}
-    )
-
-    grid = Grid.load(config.file_location('grids/basic-4x4.toml'))
-    map_output = tmp_path / 'mapped.zarr'
-    map_phase(
-        ntrajs=1,
-        species=[Species.CO2],
-        traj_iter=iter([traj]),
-        grid=grid,
-        map_output=str(map_output),
-    )
-
-    mapped = zarr.open_array(store=str(map_output), mode='r')
-    np.testing.assert_allclose(
-        np.sum(mapped[..., 0]),
-        np.sum(segment_emissions[:-1]),
-        rtol=1e-6,
-    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_matlab_verification.py
+++ b/tests/test_matlab_verification.py
@@ -1,13 +1,15 @@
 import tomllib
 
+import numpy as np
 import pandas as pd
 import pytest
 
 import AEIC.trajectories.builders as tb
+from AEIC.config.emissions import ClimbDescentMode
 from AEIC.emissions import compute_emissions
 from AEIC.missions import Mission
 from AEIC.performance.models import PerformanceModel
-from AEIC.types import Fuel
+from AEIC.types import Fuel, Species
 from AEIC.verification.legacy import LegacyTrajectory, process_matlab_csvs
 from AEIC.verification.metrics import out_of_tolerance
 
@@ -91,6 +93,20 @@ def test_matlab_verification(test_data_dir) -> None:
 
         # Record any metrics that are outside tolerance.
         bad_metrics = out_of_tolerance(metrics, mape_pct_tol=0.25)
+
+        # MATLAB computes per-leg fuel burn with diff(fuelBurnFlight), so its
+        # aircraft-mass differences are an independent oracle for both the
+        # amount and point alignment of Python's fuel_burn_per_segment.
+        matlab_fuel_burn = (
+            legacy_traj.aircraft_mass[:-1] - legacy_traj.aircraft_mass[1:]
+        )
+        python_fuel_burn = new_traj.fuel_burn_per_segment[:-1]
+        normalized_mae = np.mean(np.abs(python_fuel_burn - matlab_fuel_burn)) / (
+            np.mean(matlab_fuel_burn)
+        )
+        if normalized_mae > 0.01 or new_traj.fuel_burn_per_segment[-1] != 0.0:
+            bad_metrics.append('fuel_burn_per_segment')
+
         if len(bad_metrics) > 0:
             failed.append((mission.label, bad_metrics))
 
@@ -102,6 +118,43 @@ def test_matlab_verification(test_data_dir) -> None:
                 print(f'    {m}')
 
     assert len(failed) == 0, 'Missions with metrics outside tolerance'
+
+
+@pytest.mark.config_updates(
+    use_weather=False,
+    emissions__climb_descent_mode=ClimbDescentMode.LTO,
+)
+def test_lto_cruise_segments_match_matlab(test_data_dir) -> None:
+    """The Python LTO slice selects the same physical legs as MATLAB.
+
+    ``cruiseEmissions_byFlight.m`` classifies a leg from point ``i`` to
+    ``i + 1`` as cruise when ``diff(altFlight) == 0`` and evaluates that leg
+    at point ``i``. The committed MATLAB trajectories provide the independent
+    altitude profile used here.
+    """
+    data_dir = test_data_dir / 'verification/legacy'
+    legacy_dir = data_dir / 'matlab-output'
+    pm = PerformanceModel.load(data_dir / 'performance-model.toml')
+
+    with open(data_dir / 'missions.toml', 'rb') as fp:
+        missions = Mission.from_toml(tomllib.load(fp))
+    with open(data_dir / 'fuel.toml', 'rb') as fp:
+        fuel = Fuel.model_validate(tomllib.load(fp))
+
+    builder = tb.LegacyBuilder(options=tb.Options(iterate_mass=False))
+    for mission in missions:
+        matlab_traj = LegacyTrajectory(legacy_dir / f'{mission.label}.csv').trajectory()
+        python_traj = builder.fly(pm, mission)
+        emissions = compute_emissions(pm, fuel, python_traj)
+
+        matlab_cruise_legs = np.diff(matlab_traj.altitude) == 0.0
+        python_emitted_legs = emissions.trajectory_emissions[Species.CO2][:-1] > 0.0
+
+        np.testing.assert_array_equal(
+            python_emitted_legs,
+            matlab_cruise_legs,
+            err_msg=f'Cruise segment mismatch for {mission.label}',
+        )
 
 
 def _write_csv(path, rows):


### PR DESCRIPTION
When calculating fuel burn, the fuel burn between index i and i+1 was being stored at index i+1.
This meant that during phase changes, when there are large changes in EI(HC) or (CO), the wrong indexing of fuel burn can lead to large errors in HC/CO emissions
Storing fuel burn at index i is how MATLAB AEIC did it since it called `diff(totalFuelBurn)`

(I used GPT5.6 to help me write the tests, happy to go back and write them myself if you'd like)