### PR TITLE
Fixed east/north velocity swap, crosswind bug

### DIFF
--- a/src/AEIC/trajectories/builders/adjustable_legacy.py
+++ b/src/AEIC/trajectories/builders/adjustable_legacy.py
@@ -453,15 +453,19 @@ class AdjustableLegacyBuilder(Builder):
             # Ground speed, including weather effects if required.
             if self.weather is None:
                 pt.ground_speed = fwd_tas
+                pt.heading = pt.azimuth
             else:
-                pt.ground_speed = self.weather.get_ground_speed(
+                track_vector = self.weather.get_track_vector(
                     time=self.mission.departure,
                     gt_point=self.ground_track.location(pt.ground_distance),
                     altitude=start_altitude,
-                    true_airspeed=fwd_tas,
-                    azimuth=pt.azimuth,
+                    horizontal_airspeed=fwd_tas,
+                    track_azimuth=pt.azimuth,
                 )
-            pt.heading = pt.azimuth
+                pt.ground_speed, pt.heading = (
+                    track_vector.ground_speed,
+                    track_vector.heading,
+                )
 
             pt.altitude = end_altitude
             pt.flight_level = pt.altitude * METERS_TO_FL
@@ -573,16 +577,20 @@ class AdjustableLegacyBuilder(Builder):
             )
 
             if self.weather is not None:
-                pt.ground_speed = self.weather.get_ground_speed(
+                track_vector = self.weather.get_track_vector(
                     time=self.mission.departure,
                     gt_point=self.ground_track.location(distance),
                     altitude=pt.altitude,
-                    true_airspeed=perf.true_airspeed,
-                    azimuth=pt.azimuth,
+                    horizontal_airspeed=perf.true_airspeed,
+                    track_azimuth=pt.azimuth,
+                )
+                pt.ground_speed, pt.heading = (
+                    track_vector.ground_speed,
+                    track_vector.heading,
                 )
             else:
                 pt.ground_speed = perf.true_airspeed
-            pt.heading = pt.azimuth
+                pt.heading = pt.azimuth
 
             # Take step along great circle route.
             gpt = self.ground_track.location(distance)

--- a/src/AEIC/trajectories/builders/adjustable_legacy.py
+++ b/src/AEIC/trajectories/builders/adjustable_legacy.py
@@ -444,7 +444,7 @@ class AdjustableLegacyBuilder(Builder):
                 flight_rule,
             )
 
-            fwd_tas = np.sqrt(perf.true_airspeed**2 - perf.rate_of_climb**2)
+            horizontal_airspeed = np.sqrt(perf.true_airspeed**2 - perf.rate_of_climb**2)
 
             # Time to complete altitude change segment and total fuel burned.
             seg_time = (end_altitude - start_altitude) / perf.rate_of_climb
@@ -452,14 +452,14 @@ class AdjustableLegacyBuilder(Builder):
 
             # Ground speed, including weather effects if required.
             if self.weather is None:
-                pt.ground_speed = fwd_tas
+                pt.ground_speed = horizontal_airspeed
                 pt.heading = pt.azimuth
             else:
                 track_vector = self.weather.get_track_vector(
                     time=self.mission.departure,
                     gt_point=self.ground_track.location(pt.ground_distance),
                     altitude=start_altitude,
-                    horizontal_airspeed=fwd_tas,
+                    horizontal_airspeed=horizontal_airspeed,
                     track_azimuth=pt.azimuth,
                 )
                 pt.ground_speed, pt.heading = (

--- a/src/AEIC/trajectories/builders/legacy.py
+++ b/src/AEIC/trajectories/builders/legacy.py
@@ -327,15 +327,19 @@ class LegacyBuilder(Builder):
             # Ground speed, including weather effects if required.
             if self.weather is None:
                 pt.ground_speed = fwd_tas
+                pt.heading = pt.azimuth
             else:
-                pt.ground_speed = self.weather.get_ground_speed(
+                track_vector = self.weather.get_track_vector(
                     time=self.mission.departure,
                     gt_point=self.ground_track.location(pt.ground_distance),
                     altitude=start_altitude,
-                    true_airspeed=fwd_tas,
-                    azimuth=pt.azimuth,
+                    horizontal_airspeed=fwd_tas,
+                    track_azimuth=pt.azimuth,
                 )
-            pt.heading = pt.azimuth
+                pt.ground_speed, pt.heading = (
+                    track_vector.ground_speed,
+                    track_vector.heading,
+                )
 
             pt.altitude = end_altitude
             pt.flight_level = pt.altitude * METERS_TO_FL
@@ -446,16 +450,20 @@ class LegacyBuilder(Builder):
             )
 
             if self.weather is not None:
-                pt.ground_speed = self.weather.get_ground_speed(
+                track_vector = self.weather.get_track_vector(
                     time=self.mission.departure,
                     gt_point=self.ground_track.location(distance),
                     altitude=pt.altitude,
-                    true_airspeed=perf.true_airspeed,
-                    azimuth=pt.azimuth,
+                    horizontal_airspeed=perf.true_airspeed,
+                    track_azimuth=pt.azimuth,
+                )
+                pt.ground_speed, pt.heading = (
+                    track_vector.ground_speed,
+                    track_vector.heading,
                 )
             else:
                 pt.ground_speed = perf.true_airspeed
-            pt.heading = pt.azimuth
+                pt.heading = pt.azimuth
 
             # Take step along great circle route.
             gpt = self.ground_track.location(distance)

--- a/src/AEIC/trajectories/builders/legacy.py
+++ b/src/AEIC/trajectories/builders/legacy.py
@@ -318,7 +318,7 @@ class LegacyBuilder(Builder):
                 flight_rule,
             )
 
-            fwd_tas = np.sqrt(perf.true_airspeed**2 - perf.rate_of_climb**2)
+            horizontal_airspeed = np.sqrt(perf.true_airspeed**2 - perf.rate_of_climb**2)
 
             # Time to complete altitude change segment and total fuel burned.
             seg_time = (end_altitude - start_altitude) / perf.rate_of_climb
@@ -326,14 +326,14 @@ class LegacyBuilder(Builder):
 
             # Ground speed, including weather effects if required.
             if self.weather is None:
-                pt.ground_speed = fwd_tas
+                pt.ground_speed = horizontal_airspeed
                 pt.heading = pt.azimuth
             else:
                 track_vector = self.weather.get_track_vector(
                     time=self.mission.departure,
                     gt_point=self.ground_track.location(pt.ground_distance),
                     altitude=start_altitude,
-                    horizontal_airspeed=fwd_tas,
+                    horizontal_airspeed=horizontal_airspeed,
                     track_azimuth=pt.azimuth,
                 )
                 pt.ground_speed, pt.heading = (

--- a/src/AEIC/weather.py
+++ b/src/AEIC/weather.py
@@ -1,4 +1,5 @@
 import gc
+from dataclasses import dataclass
 from pathlib import Path
 
 import numpy as np
@@ -13,6 +14,43 @@ from AEIC.config.weather import (
 )
 from AEIC.trajectories.ground_track import GroundTrack
 from AEIC.utils.standard_atmosphere import pressure_at_altitude_isa_bada4
+
+
+@dataclass(frozen=True)
+class GroundTrackVector:
+    """Aircraft ground speed and heading required
+    to follow a prescribed ground track."""
+
+    ground_speed: float
+    heading: float
+
+
+def solve_track_vector(
+    track_azimuth: float,
+    horizontal_airspeed: float,
+    wind_east: float,
+    wind_north: float,
+) -> GroundTrackVector:
+    """Solve the wind triangle for a prescribed ground-track azimuth."""
+    if horizontal_airspeed <= 0:
+        raise ValueError('horizontal airspeed must be positive')
+
+    track_rad = np.deg2rad(track_azimuth)
+    wind_parallel = wind_east * np.sin(track_rad) + wind_north * np.cos(track_rad)
+    wind_cross = wind_east * np.cos(track_rad) - wind_north * np.sin(track_rad)
+    if abs(wind_cross) >= horizontal_airspeed:
+        raise ValueError('crosswind is too strong to maintain the prescribed track')
+
+    air_parallel = np.sqrt(horizontal_airspeed**2 - wind_cross**2)
+    ground_speed = air_parallel + wind_parallel
+    if ground_speed <= 0:
+        raise ValueError('wind produces non-positive along-track ground speed')
+
+    # Difference between an aircraft's heading (where the nose is pointed)
+    # and its actual track over the ground
+    crab_angle = np.arctan2(-wind_cross, air_parallel)
+    heading = (track_azimuth + np.rad2deg(crab_angle)) % 360
+    return GroundTrackVector(float(ground_speed), float(heading))
 
 
 class Weather:
@@ -243,6 +281,19 @@ class Weather:
             Ground speed [m/s]
         """
 
+        return self.get_track_vector(
+            time, gt_point, altitude, true_airspeed, azimuth
+        ).ground_speed
+
+    def get_track_vector(
+        self,
+        time: pd.Timestamp,
+        gt_point: GroundTrack.Point,
+        altitude: float,
+        horizontal_airspeed: float,
+        track_azimuth: float | None = None,
+    ) -> GroundTrackVector:
+        """Compute ground speed and crabbed heading along a prescribed track."""
         self._require_data(time)
         assert self._ds is not None
 
@@ -260,12 +311,11 @@ class Weather:
         if wind_u.isnull().values.any() or wind_v.isnull().values.any():
             raise ValueError('ground track point is outside weather data domain')
 
-        if azimuth is None:
-            heading_rad = np.deg2rad(gt_point.azimuth)
-        else:
-            heading_rad = np.deg2rad(azimuth)
-
-        u_air = true_airspeed * np.cos(heading_rad)
-        v_air = true_airspeed * np.sin(heading_rad)
-
-        return float(np.hypot(u_air + wind_u, v_air + wind_v))
+        if track_azimuth is None:
+            track_azimuth = gt_point.azimuth
+        return solve_track_vector(
+            track_azimuth,
+            horizontal_airspeed,
+            wind_east=wind_u.item(),
+            wind_north=wind_v.item(),
+        )

--- a/tests/test_trajectory_simulation.py
+++ b/tests/test_trajectory_simulation.py
@@ -133,6 +133,7 @@ def test_trajectory_simulation_weather(example_mission_with_weather, performance
 
     assert len(traj_wx) > 0
     assert np.any(traj_wx.ground_speed != traj_nowx.ground_speed)
+    assert np.any(~np.isclose(traj_wx.heading, traj_wx.azimuth))
 
 
 def test_trajectory_mass_iter(performance_model, example_mission, iteration_params):

--- a/tests/test_weather.py
+++ b/tests/test_weather.py
@@ -11,7 +11,7 @@ from AEIC.missions import Mission
 from AEIC.missions.mission import iso_to_timestamp
 from AEIC.trajectories.ground_track import GroundTrack
 from AEIC.types import Location
-from AEIC.weather import Weather
+from AEIC.weather import Weather, solve_track_vector
 
 # Sample mission
 sample_mission = Mission(
@@ -85,11 +85,51 @@ _PROBE_LOCATION = Location(longitude=-75.0, latitude=40.0)
 _PROBE_POINT = GroundTrack.Point(location=_PROBE_LOCATION, azimuth=0.0)
 _PROBE_ALT = 9144.0  # ~300 hPa by ISA
 _PROBE_TAS = 200.0
-# Constants in synthetic fields; with azimuth=0, cos=1 sin=0 →
-# u_air=200, v_air=0, so ground speed = hypot(200 + 5, 0 + 0) = 205.
-_WIND_U = 5.0
-_WIND_V = 0.0
+# Constants in synthetic fields; positive northward wind is a tailwind for the
+# default northbound probe.
+_WIND_U = 0.0
+_WIND_V = 5.0
 _EXPECTED_GS = 205.0
+
+
+@pytest.mark.parametrize(
+    ('azimuth', 'wind_east', 'wind_north'),
+    [(0.0, 0.0, 5.0), (90.0, 5.0, 0.0)],
+)
+def test_track_vector_uses_compass_azimuth(azimuth, wind_east, wind_north):
+    vector = solve_track_vector(azimuth, 200.0, wind_east, wind_north)
+    assert vector.ground_speed == pytest.approx(205.0)
+    assert vector.heading == pytest.approx(azimuth)
+
+
+def test_track_vector_headwind_and_tailwind():
+    assert solve_track_vector(0, 200, 0, 20).ground_speed == pytest.approx(220)
+    assert solve_track_vector(0, 200, 0, -20).ground_speed == pytest.approx(180)
+
+
+def test_track_vector_crosswind_crabs_to_hold_track():
+    right = solve_track_vector(0, 200, 20, 0)
+    left = solve_track_vector(0, 200, -20, 0)
+
+    assert right.ground_speed == pytest.approx(np.sqrt(200**2 - 20**2))
+    assert left.ground_speed == pytest.approx(right.ground_speed)
+    assert right.heading == pytest.approx(360 - left.heading)
+
+    heading_rad = np.deg2rad(right.heading)
+    aircraft_east = 200 * np.sin(heading_rad)
+    assert aircraft_east + 20 == pytest.approx(0)
+
+
+@pytest.mark.parametrize(
+    ('wind_east', 'wind_north', 'message'),
+    [
+        (200.0, 0.0, 'crosswind is too strong'),
+        (0.0, -200.0, 'non-positive along-track ground speed'),
+    ],
+)
+def test_track_vector_rejects_impossible_wind(wind_east, wind_north, message):
+    with pytest.raises(ValueError, match=message):
+        solve_track_vector(0, 200, wind_east, wind_north)
 
 
 def _make_field(shape: tuple[int, ...], value: float) -> np.ndarray:
@@ -420,14 +460,14 @@ def test_monthly_in_annual_picks_correct_month_at_period_boundary(tmp_path):
     lat_count = len(_LATITUDES)
     lon_count = len(_LONGITUDES)
 
-    # Per-month wind_u: month 1 → 1.0, month 2 → 2.0, ..., month 12 → 12.0.
+    # Per-month northward wind: month 1 → 1.0, ..., month 12 → 12.0.
     months = list(range(1, 13))
     vt = pd.DatetimeIndex([pd.Timestamp(f'2024-{m:02d}-15') for m in months])
-    u_vals = np.zeros((12, pl_count, lat_count, lon_count), dtype=np.float32)
+    v_vals = np.zeros((12, pl_count, lat_count, lon_count), dtype=np.float32)
     for i, m in enumerate(months):
-        u_vals[i, ...] = float(m)
-    v_vals = np.zeros_like(u_vals)
-    t_vals = np.full_like(u_vals, 220.0)
+        v_vals[i, ...] = float(m)
+    u_vals = np.zeros_like(v_vals)
+    t_vals = np.full_like(v_vals, 220.0)
 
     ds = xr.Dataset(
         {
@@ -458,11 +498,10 @@ def test_monthly_in_annual_picks_correct_month_at_period_boundary(tmp_path):
         file_resolution=TemporalResolution.ANNUAL,
         data_resolution=TemporalResolution.MONTHLY,
     )
-    # Query on 2024-03-31. Expected u_air = 200 (TAS, azimuth=0); wind_u for
-    # March is 3.0; ground speed = hypot(203, 0) = 203.
+    # Query on 2024-03-31. March's northward tailwind is 3 m/s.
     gs = _run_probe(w, pd.Timestamp('2024-03-31T23:00'))
     assert gs == pytest.approx(203.0, rel=1e-4)
-    # Sanity check: querying in April returns wind_u=4 → gs=204.
+    # Sanity check: querying in April returns a 4 m/s tailwind.
     gs = _run_probe(w, pd.Timestamp('2024-04-15T00:00'))
     assert gs == pytest.approx(204.0, rel=1e-4)
 
@@ -652,8 +691,8 @@ def test_explicit_azimuth_overrides_ground_track_azimuth(tmp_path):
         file_resolution=TemporalResolution.ANNUAL,
         file_format='annual.nc',
     )
-    # azimuth=0 (gt_point default) → u_air=TAS, gs = hypot(TAS+wind_u, 0).
-    # azimuth=90 (east) → v_air=TAS, gs = hypot(wind_u, TAS).
+    # The default northbound track gets a tailwind; the eastbound override gets
+    # the same wind as a crosswind.
     gs_auto = w.get_ground_speed(
         time=pd.Timestamp('2024-06-15'),
         gt_point=_PROBE_POINT,
@@ -668,7 +707,7 @@ def test_explicit_azimuth_overrides_ground_track_azimuth(tmp_path):
         azimuth=90.0,
     )
     assert gs_auto == pytest.approx(_EXPECTED_GS, rel=1e-4)
-    assert gs_east == pytest.approx(float(np.hypot(_WIND_U, _PROBE_TAS)), rel=1e-4)
+    assert gs_east == pytest.approx(np.sqrt(_PROBE_TAS**2 - _WIND_V**2), rel=1e-4)
     assert gs_auto != gs_east
 
 


### PR DESCRIPTION
Geographic azimuth is clockwise from north, so east velocity should use TAS × sin(azimuth) and north should use TAS × cos(azimuth). We currently do the reverse, effectively treating northbound aircraft as eastbound when applying wind.

Also we add wind and aircraft velocity vectors and take their magnitude, while still forcing the aircraft along the prescribed track. It does not calculate the crab angle needed to maintain that track. Crosswind can therefore incorrectly alter flight time, fuel burn, and emissions.

(This is a bug unique to python AEIC, MATLAB AEIC did it the right way)