### PR TITLE
BFFM2/HCCO bug fix and validation against MATLAB

### DIFF
--- a/src/AEIC/emissions/ei/hcco.py
+++ b/src/AEIC/emissions/ei/hcco.py
@@ -127,7 +127,7 @@ def EI_HCCO(
     # Lower segment: log_ff < x_intercept
     lower_mask = positive_mask & (log_ff < x_intercept)
     # Upper segment: log_ff >= x_intercept
-    upper_mask = log_ff >= x_intercept
+    upper_mask = positive_mask & (log_ff >= x_intercept)
 
     # Slanted‐line formula for "lower" points
     if np.any(lower_mask):

--- a/src/AEIC/emissions/trajectory.py
+++ b/src/AEIC/emissions/trajectory.py
@@ -117,25 +117,17 @@ def compute_EI_NOx(
         case EINOxMethod.NONE:
             pass
         case EINOxMethod.BFFM2:
-            try:
-                bffm2_result = BFFM2_EINOx(
-                    sls_equiv_fuel_flow=sls_equiv_fuel_flow,
-                    EI_NOx_matrix=lto.EI_NOx,
-                    fuelflow_performance=lto.fuel_flow,
-                    Pamb=atmos_state.pressure,
-                    Tamb=atmos_state.temperature,
-                )
-                indices[Species.NOx] = bffm2_result.NOxEI
-                indices[Species.NO] = bffm2_result.NOEI
-                indices[Species.NO2] = bffm2_result.NO2EI
-                indices[Species.HONO] = bffm2_result.HONOEI
-            except Exception:
-                print('BBFM2 NOx calculation failed.')
-                print(f'sls_equiv_fuel_flow: {sls_equiv_fuel_flow}')
-                print(f'EI_NOx_matrix: {lto.EI_NOx}')
-                print(f'fuelflow_performance: {lto.fuel_flow}')
-                print(f'Pamb: {atmos_state.pressure}')
-                print(f'Tamb: {atmos_state.temperature}')
+            bffm2_result = BFFM2_EINOx(
+                sls_equiv_fuel_flow=sls_equiv_fuel_flow,
+                EI_NOx_matrix=lto.EI_NOx,
+                fuelflow_performance=lto.fuel_flow,
+                Pamb=atmos_state.pressure,
+                Tamb=atmos_state.temperature,
+            )
+            indices[Species.NOx] = bffm2_result.NOxEI
+            indices[Species.NO] = bffm2_result.NOEI
+            indices[Species.NO2] = bffm2_result.NO2EI
+            indices[Species.HONO] = bffm2_result.HONOEI
         case EINOxMethod.P3T3:
             print("P3T3 method not implemented yet..")
         case _:

--- a/tests/test_emission_functions.py
+++ b/tests/test_emission_functions.py
@@ -116,6 +116,44 @@ class TestEI_HCCO:
         assert np.all(np.isfinite(result))
         assert np.all(result >= 0.0)
 
+    def test_zero_fuel_flow_matches_matlab_zero_output(self):
+        """MATLAB leaves zero-flow points at the initialized zero EI."""
+        # This calibration puts log10(0)'s Python placeholder above the
+        # HCCO intercept, exposing an upper-branch mask that omits ff > 0.
+        x_ei = ThrustModeValues(1.54, 0.05, 0.02, 0.03)
+        fuel_flow_calibration = ThrustModeValues(0.4, 0.8, 1.2, 1.8)
+
+        result = EI_HCCO(
+            np.array([0.0]),
+            x_ei,
+            fuel_flow_calibration,
+            self.Tamb,
+            self.Pamb,
+        )
+
+        np.testing.assert_array_equal(result, np.array([0.0]))
+
+    def test_duplicate_calibration_flows_flatten_slanted_segment(self):
+        """Duplicate calibration flows should force a flat lower segment"""
+        fuelflow_eval = np.array([0.15, 0.25, 0.3, 0.5])
+        x_EI_matrix = ThrustModeValues(10.0, 10.0, 5.0, 3.0)
+        fuelflow_calibrate = ThrustModeValues(0.3, 0.3, 0.7, 1.4)
+
+        result = EI_HCCO(
+            fuelflow_eval, x_EI_matrix, fuelflow_calibrate, self.Tamb, self.Pamb
+        )
+        expected_upper = np.sqrt(
+            x_EI_matrix[ThrustMode.CLIMB] * x_EI_matrix[ThrustMode.TAKEOFF]
+        )
+        expected = np.full_like(fuelflow_eval, expected_upper)
+
+        low_thrust_mask = fuelflow_eval < fuelflow_calibrate[ThrustMode.IDLE]
+        expected[low_thrust_mask] *= 1 - 52.0 * (
+            fuelflow_eval[low_thrust_mask] - fuelflow_calibrate[ThrustMode.IDLE]
+        )
+
+        assert np.allclose(result, expected)
+
     def test_intercept_adjustment_uses_second_mode_value(self):
         """When intercept drifts low, the second mode should set the ceiling"""
         x_EI_matrix = ThrustModeValues(

--- a/tests/test_emission_functions.py
+++ b/tests/test_emission_functions.py
@@ -127,32 +127,30 @@ class TestEI_HCCO:
             np.array([0.0]),
             x_ei,
             fuel_flow_calibration,
-            self.Tamb,
-            self.Pamb,
+            288.15,
+            101325.0,
         )
 
         np.testing.assert_array_equal(result, np.array([0.0]))
 
     def test_duplicate_calibration_flows_flatten_slanted_segment(self):
-        """Duplicate calibration flows should force a flat lower segment"""
+        """Duplicate calibration flows make the fitted EI invariant to flow."""
         fuelflow_eval = np.array([0.15, 0.25, 0.3, 0.5])
-        x_EI_matrix = ThrustModeValues(10.0, 10.0, 5.0, 3.0)
+        x_EI_matrix = ThrustModeValues(10.0, 8.0, 5.0, 3.0)
         fuelflow_calibrate = ThrustModeValues(0.3, 0.3, 0.7, 1.4)
 
         result = EI_HCCO(
-            fuelflow_eval, x_EI_matrix, fuelflow_calibrate, self.Tamb, self.Pamb
+            fuelflow_eval,
+            x_EI_matrix,
+            fuelflow_calibrate,
+            288.15,
+            101325.0,
         )
-        expected_upper = np.sqrt(
+        expected = np.sqrt(
             x_EI_matrix[ThrustMode.CLIMB] * x_EI_matrix[ThrustMode.TAKEOFF]
         )
-        expected = np.full_like(fuelflow_eval, expected_upper)
 
-        low_thrust_mask = fuelflow_eval < fuelflow_calibrate[ThrustMode.IDLE]
-        expected[low_thrust_mask] *= 1 - 52.0 * (
-            fuelflow_eval[low_thrust_mask] - fuelflow_calibrate[ThrustMode.IDLE]
-        )
-
-        assert np.allclose(result, expected)
+        np.testing.assert_allclose(result, expected)
 
     def test_intercept_adjustment_uses_second_mode_value(self):
         """When intercept drifts low, the second mode should set the ceiling"""

--- a/tests/test_emissions.py
+++ b/tests/test_emissions.py
@@ -13,6 +13,7 @@ from AEIC.emissions.gse import get_GSE_emissions
 from AEIC.emissions.trajectory import (
     _calculate_EI_nvPM,
     _trajectory_slice,
+    compute_EI_NOx,
 )
 from AEIC.emissions.types import AtmosphericState
 from AEIC.emissions.utils import (
@@ -128,6 +129,29 @@ def test_emissions_species(emissions):
     species and added a stray duplicate.
     """
     assert emissions.species == set(Species)
+
+
+def test_bffm2_failure_is_not_silently_dropped(monkeypatch, perf_model, trajectory):
+    """Match MATLAB's fail-fast BFFM2 call instead of omitting NOx."""
+    error = RuntimeError('invalid BFFM2 calibration')
+
+    def fail_bffm2(**_kwargs):
+        raise error
+
+    monkeypatch.setattr(
+        'AEIC.emissions.trajectory.BFFM2_EINOx',
+        fail_bffm2,
+    )
+    atmos_state = AtmosphericState(trajectory.altitude, trajectory.true_airspeed)
+
+    with pytest.raises(RuntimeError) as exc_info:
+        compute_EI_NOx(
+            perf_model.lto,
+            atmos_state,
+            np.ones(len(trajectory)),
+        )
+
+    assert exc_info.value is error
 
 
 def _expected_trajectory_indices(perf_model, trajectory):


### PR DESCRIPTION
- BFFM2 errors must propagate instead of totally removing NOx emissions. MATLAB calls noxEIsFunc directly without a fallback in Model_Files/cruiseEmissions_byFlight.m:177-184. 
- HCCO now returns zero at zero fuel flow. MATLAB initializes the output to zero and only evaluates positive fuel flow in Model_Files/hccoEIsFunc.m:55-75. This repo changed log10(0) with 0, which could be incorrect.

Added test:
`test_bffm2_failure_is_not_silently_dropped` makes BFFM2 raise a known exception and verifies that the exact exception propagates from compute_EI_NOx.
`test_zero_fuel_flow_matches_matlab_zero_output` uses a calibration that would expose the old placeholder-log behavior and verifies an exact zero HCCO result.