### PR TITLE
MATALB Validation fixes: Lifecycle, APU, GSE

### DIFF
--- a/src/AEIC/emissions/apu.py
+++ b/src/AEIC/emissions/apu.py
@@ -6,6 +6,7 @@ from AEIC.performance.types import ThrustMode, ThrustModeValues
 from AEIC.types import Fuel, Species, SpeciesValues
 
 from .ei.nox import NOx_speciation
+from .ei.sox import EI_SOx
 
 
 def get_APU_emissions(
@@ -36,12 +37,9 @@ def get_APU_emissions(
     apu_fuel_burn = apu.fuel_kg_per_s * apu_time
 
     # SOx
-    indices[Species.SO2] = (
-        lto_indices[Species.SO2][ThrustMode.IDLE] if apu_running else 0.0
-    )
-    indices[Species.SO4] = (
-        lto_indices[Species.SO4][ThrustMode.IDLE] if apu_running else 0.0
-    )
+    sox = EI_SOx(fuel)
+    indices[Species.SO2] = sox.EI_SO2 if apu_running else 0.0
+    indices[Species.SO4] = sox.EI_SO4 if apu_running else 0.0
     indices[Species.SOx] = indices[Species.SO2] + indices[Species.SO4]
 
     # Non-volatile PM estimate (deterministic BC fraction of 0.95).
@@ -79,6 +77,13 @@ def get_APU_emissions(
     else:
         indices[Species.CO2] = 0.0
 
+    indices = SpeciesValues[float](
+        {
+            species: value
+            for species, value in indices.items()
+            if species in config.emissions.enabled_species
+        }
+    )
     for species in indices:
         emissions[species] = indices[species] * apu_fuel_burn
 

--- a/src/AEIC/emissions/emission.py
+++ b/src/AEIC/emissions/emission.py
@@ -215,7 +215,11 @@ def compute_emissions(
         Species.CO2 in config.emissions.enabled_species
         and config.emissions.lifecycle_enabled
     ):
-        lifecycle_adjustment = get_lifecycle_emissions(fuel, traj)
+        lifecycle_adjustment = get_lifecycle_emissions(
+            fuel,
+            total_fuel_burn,
+            emissions.total_emissions[Species.CO2],
+        )
         emissions.total_emissions[Species.CO2] += lifecycle_adjustment
         emissions.lifecycle_co2 = lifecycle_adjustment
 
@@ -248,9 +252,13 @@ def sum_total_emissions(
     return result
 
 
-def get_lifecycle_emissions(fuel: Fuel, traj) -> float:
-    """Calculate lifecycle CO₂ adjustments."""
+def get_lifecycle_emissions(
+    fuel: Fuel,
+    total_fuel_burn: float,
+    operational_co2: float,
+) -> float:
+    """Return the adjustment from operational to lifecycle CO₂ emissions."""
     if fuel.lifecycle_CO2 is None:
         raise RuntimeError('Lifecycle CO2 data not available for selected fuel.')
-    fuel_used = traj.fuel_mass[0] - traj.fuel_mass[-1]
-    return float(fuel.lifecycle_CO2 * (fuel_used * fuel.energy_MJ_per_kg))
+    lifecycle_total = fuel.lifecycle_CO2 * total_fuel_burn * fuel.energy_MJ_per_kg
+    return float(lifecycle_total - operational_co2)

--- a/src/AEIC/emissions/gse.py
+++ b/src/AEIC/emissions/gse.py
@@ -53,6 +53,13 @@ def get_GSE_emissions(
     if Species.nvPM_N in config.emissions.enabled_species:
         gse[Species.nvPM_N] = 0.0
 
+    gse = SpeciesValues[float](
+        {
+            species: value
+            for species, value in gse.items()
+            if species in config.emissions.enabled_species
+        }
+    )
     return EmissionsSubset(emissions=gse, fuel_burn=gse_fuel)
 
 

--- a/src/AEIC/emissions/gse.py
+++ b/src/AEIC/emissions/gse.py
@@ -39,10 +39,11 @@ def get_GSE_emissions(
     MWT_O2 = 16.0 * 2
     MWT_SO2 = 32.0 + 16.0 * 2
     MWT_SO4 = 32.0 + 16.0 * 4
-    # g SO₄ per kg fuel:
-    gse[Species.SO4] = GSE_FSC * KG_TO_GRAMS * GSE_EPS * (MWT_SO4 / MWT_O2)
-    # g SO₂ per kg fuel:
-    gse[Species.SO2] = GSE_FSC * KG_TO_GRAMS * (1.0 - GSE_EPS) * (MWT_SO2 / MWT_O2)
+    # Convert the MATLAB emission indices [g / kg fuel] to per-cycle grams.
+    so4_ei = GSE_FSC * KG_TO_GRAMS * GSE_EPS * (MWT_SO4 / MWT_O2)
+    so2_ei = GSE_FSC * KG_TO_GRAMS * (1.0 - GSE_EPS) * (MWT_SO2 / MWT_O2)
+    gse[Species.SO4] = so4_ei * gse_fuel
+    gse[Species.SO2] = so2_ei * gse_fuel
     gse[Species.SOx] = gse[Species.SO4] + gse[Species.SO2]
 
     # Subtract sulfate from core PM₁₀ and map remainder to nvPM.

--- a/tests/test_emissions.py
+++ b/tests/test_emissions.py
@@ -585,3 +585,23 @@ def test_get_gse_emissions_matches_reference_profile(fuel):
         assert result[species] == pytest.approx(value)
     if Species.nvPM_N in result:
         assert result[Species.nvPM_N] == pytest.approx(0.0)
+
+
+@pytest.mark.parametrize(
+    ('aircraft_class', 'matlab_pm10'),
+    [
+        (AircraftClass.WIDE, 55.0),
+        (AircraftClass.NARROW, 25.0),
+        (AircraftClass.SMALL, 20.0),
+        (AircraftClass.FREIGHT, 55.0),
+    ],
+)
+def test_gse_nvpm_matches_matlab_pm_remainder(aircraft_class, matlab_pm10, fuel):
+    gse = get_GSE_emissions(aircraft_class, fuel)
+    matlab_so4_ei = 5.0e-6 * 1000.0 * 0.02 * (96.0 / 32.0)
+    expected_so4 = matlab_so4_ei * gse.fuel_burn
+
+    assert gse.emissions[Species.SO4] == pytest.approx(expected_so4)
+    assert gse.emissions[Species.nvPM] + gse.emissions[Species.SO4] == pytest.approx(
+        matlab_pm10
+    )

--- a/tests/test_emissions.py
+++ b/tests/test_emissions.py
@@ -326,6 +326,29 @@ def test_apu_disabled_short_circuits(perf_model, fuel, trajectory):
     assert dict(output.apu_emissions) == {}
 
 
+@pytest.mark.config_updates(emissions__lifecycle_enabled=True)
+def test_lifecycle_co2_replaces_operational_co2_for_all_fuel(
+    perf_model, fuel, trajectory
+):
+    emissions = compute_emissions(perf_model, fuel, trajectory)
+    operational_co2 = (
+        np.sum(emissions.trajectory_emissions[Species.CO2])
+        + emissions.lto_emissions[Species.CO2].sum()
+        + emissions.apu_emissions[Species.CO2]
+        + emissions.gse_emissions[Species.CO2]
+    )
+    expected_lifecycle_total = (
+        fuel.lifecycle_CO2 * fuel.energy_MJ_per_kg * emissions.total_fuel_burn
+    )
+
+    assert emissions.total_emissions[Species.CO2] == pytest.approx(
+        expected_lifecycle_total
+    )
+    assert emissions.lifecycle_co2 == pytest.approx(
+        expected_lifecycle_total - operational_co2
+    )
+
+
 def test_scope11_profile_caching(perf_model):
     profile_first = scope11_profile(perf_model.edb)
     profile_second = scope11_profile(perf_model.edb)

--- a/tests/test_emissions.py
+++ b/tests/test_emissions.py
@@ -542,10 +542,10 @@ def test_get_gse_emissions_matches_reference_profile(fuel):
     kg_to_g = 1000.0
     eps = 0.02
     mw_o2, mw_so2, mw_so4 = 32.0, 64.0, 96.0
-    so4 = fsc * kg_to_g * eps * (mw_so4 / mw_o2)
-    so2 = fsc * kg_to_g * (1.0 - eps) * (mw_so2 / mw_o2)
-
     gse_fuel = co2_wide / fuel.EI_CO2
+    so4 = fsc * kg_to_g * eps * (mw_so4 / mw_o2) * gse_fuel
+    so2 = fsc * kg_to_g * (1.0 - eps) * (mw_so2 / mw_o2) * gse_fuel
+
     expected = SpeciesValues[float](
         {
             Species.CO2: co2_wide,

--- a/tests/test_emissions.py
+++ b/tests/test_emissions.py
@@ -326,6 +326,24 @@ def test_apu_disabled_short_circuits(perf_model, fuel, trajectory):
     assert dict(output.apu_emissions) == {}
 
 
+@pytest.mark.config_updates(
+    emissions__co2_enabled=False,
+    emissions__h2o_enabled=False,
+    emissions__sox_enabled=False,
+    emissions__nox_method='none',
+    emissions__hc_method='none',
+    emissions__co_method='none',
+    emissions__nvpm_method='none',
+    emissions__lifecycle_enabled=False,
+)
+def test_apu_and_gse_exclude_disabled_species(perf_model, fuel, trajectory):
+    emissions = compute_emissions(perf_model, fuel, trajectory)
+
+    assert set(emissions.apu_indices) == set()
+    assert set(emissions.apu_emissions) == set()
+    assert set(emissions.gse_emissions) == set()
+
+
 @pytest.mark.config_updates(emissions__lifecycle_enabled=True)
 def test_lifecycle_co2_replaces_operational_co2_for_all_fuel(
     perf_model, fuel, trajectory


### PR DESCRIPTION
- Lifecycle $CO_2$ now covers total trajectory, LTO, APU, and GSE fuel. MATLAB does the same in `Model_Files/co2eqFunc.m:51-57`, `cruiseEmissions_byFlight.m:738-756`, `apuEmissions.m:46-56`, and `gseEmissions.m:17-24`.
-  GSE $SO2$ and $SO4$ EIs are now multiplied by GSE fuel burn, converting g/kg fuel to g/cycle. MATLAB does this in `gseEIs_byType.m:146-147` and `gseEIs_byType.m:28-53`. This was useful to catch a bug in the orignal MATLAB code where its GSE sulfur values are defined in g/kg fuel but and not multiplied by fuel
- APU and GSE outputs actually work with this repos `enabled_species` configuration. **This is not a fix against the MATLAB version but just a logging issue that I found.**
- GSE nvPM emissions now follow MATLAB’s calculation from `gseEIs_byType.m:104-120` and `gseEIs_byType.m:149-155`. 