### PR TITLE
Added weather option from config to sim run

### DIFF
--- a/src/AEIC/commands/run_simulations.py
+++ b/src/AEIC/commands/run_simulations.py
@@ -210,7 +210,12 @@ def run_simulations(
             fuel = Fuel.model_validate(tomllib.load(fp))
 
         # Make trajectory builder.
-        builder = tb.LegacyBuilder(options=tb.Options(iterate_mass=False))
+        builder = tb.LegacyBuilder(
+            options=tb.Options(
+                iterate_mass=False,
+                use_weather=config.weather.use_weather,
+            )
+        )
 
         simulate_slice(
             slice_index,


### PR DESCRIPTION
`run_simulations.py` has:
 
```Python
builder = tb.LegacyBuilder(options=tb.Options(iterate_mass=False))
```
where the default builder option for weather is `false`
then in `builders/legacy.py` it does
 
```Python
if builder.options.use_weather:
            self.weather = Weather(
                data_dir=config.weather.weather_data_dir,
                file_resolution=config.weather.file_resolution,
                data_resolution=config.weather.data_resolution,
                file_format=config.weather.file_format,
            )
```
so it checks `builder.options.use_weather` but nowhere is it based on `config.weather.use_weather`