### PR TITLE
Bump version: 0.3.0 → 0.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,16 +7,16 @@ Aviation Emissions Inventory Code (AEIC) is used to estimate aviation emissions 
 ## Installation
 
 `AEIC` is not currently available on PyPI, but you can install releases from
-GitHub. The latest available version is v0.3.0. If you are using `pip`, do
+GitHub. The latest available version is v0.4.0. If you are using `pip`, do
 
 ```shell
-pip install git+https://github.com/MIT-LAE/AEIC.git@v0.3.0
+pip install git+https://github.com/MIT-LAE/AEIC.git@v0.4.0
 ```
 
 If you are using `uv`, do
 
 ```shell
-uv add git+https://github.com/MIT-LAE/AEIC.git@v0.3.0
+uv add git+https://github.com/MIT-LAE/AEIC.git@v0.4.0
 ```
 
 ## Local Development

--- a/docs/main_page.md
+++ b/docs/main_page.md
@@ -10,16 +10,16 @@ gridding, and weather.
 ## Installation
 
 `AEIC` is not currently available on PyPI, but you can install releases from
-GitHub. The latest available version is v0.3.0. If you are using `pip`, do
+GitHub. The latest available version is v0.4.0. If you are using `pip`, do
 
 ```shell
-pip install git+https://github.com/MIT-LAE/AEIC.git@v0.3.0
+pip install git+https://github.com/MIT-LAE/AEIC.git@v0.4.0
 ```
 
 If you are using `uv`, do
 
 ```shell
-uv add git+https://github.com/MIT-LAE/AEIC.git@v0.3.0
+uv add git+https://github.com/MIT-LAE/AEIC.git@v0.4.0
 ```
 
 ## Units

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "AEIC"
 
-version = "0.3.0"
+version = "0.4.0"
 
 authors = [
     {name = "Wyatt Giroux", email = "girouxw@mit.edu"},
@@ -73,7 +73,7 @@ wheel-exclude = ["airports.csv"]
 source-exclude = ["airports.csv"]
 
 [tool.bumpversion]
-current_version = "0.3.0"
+current_version = "0.4.0"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)"
 serialize = ["{major}.{minor}.{patch}"]
 commit = true

--- a/uv.lock
+++ b/uv.lock
@@ -13,7 +13,7 @@ required-markers = [
 
 [[package]]
 name = "aeic"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "cachetools" },


### PR DESCRIPTION
New release before rerunning OAG 2019 simulations.